### PR TITLE
fix category notation length limit for exceptional cases

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,14 +6,14 @@ plugins {
     id 'org.springframework.boot' version '2.5.1'
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
     id 'org.liquibase.gradle' version '2.0.3'
-    id 'nu.studer.jooq' version '5.2.1'
+    id 'nu.studer.jooq' version '5.2.2'
 }
 
 bootJar.enabled(false)
 jar.enabled(true)
 
 group 'io.dsub.discogs'
-version '0.0.2.13'
+version '0.0.2.14'
 
 sourceCompatibility = JavaVersion.VERSION_16
 targetCompatibility = JavaVersion.VERSION_16
@@ -134,6 +134,7 @@ jooq {
                         records = true
                         immutablePojos = false
                         fluentSetters = true
+                        javaTimeTypes = true
                     }
                     target {
                         packageName = 'io.dsub.discogs.common.jooq.mysql'

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -156,7 +156,7 @@ databaseChangeLog:
             autoIncrement: true
             constraints:
               primaryKey: true
-              primaryKeyName: pk_label_item_release
+              primaryKeyName: pk_label_release_item
             name: id
             type: int
         - column:
@@ -171,7 +171,7 @@ databaseChangeLog:
             type: timestamp
         - column:
             name: category_notation
-            type: nvarchar(255)
+            type: nvarchar(1000)
         - column:
             constraints:
               nullable: false
@@ -182,7 +182,7 @@ databaseChangeLog:
               nullable: false
             name: release_item_id
             type: int
-        tableName: label_item_release
+        tableName: label_release_item
 - changeSet:
     id: 1624918933185-6
     author: Seunghyun Bosco Bae
@@ -1053,7 +1053,7 @@ databaseChangeLog:
     changes:
     - addForeignKeyConstraint:
         baseColumnNames: label_id
-        baseTableName: label_item_release
+        baseTableName: label_release_item
         constraintName: fk_label_release_label_id_label
         deferrable: false
         initiallyDeferred: false
@@ -1068,8 +1068,8 @@ databaseChangeLog:
     changes:
     - addUniqueConstraint:
         columnNames: release_item_id, label_id
-        constraintName: uq_label_item_release_release_item_id_label_id
-        tableName: label_item_release
+        constraintName: uq_label_release_item_release_item_id_label_id
+        tableName: label_release_item
 - changeSet:
     id: 1624918933185-35
     author: Seunghyun Bosco Bae
@@ -1520,7 +1520,7 @@ databaseChangeLog:
     changes:
     - addForeignKeyConstraint:
         baseColumnNames: release_item_id
-        baseTableName: label_item_release
+        baseTableName: label_release_item
         constraintName: fk_label_release_release_item_id_release_item
         deferrable: false
         initiallyDeferred: false

--- a/src/main/resources/mysql-init.sql
+++ b/src/main/resources/mysql-init.sql
@@ -1,6 +1,6 @@
 create table if not exists artist
 (
-    id               bigint auto_increment
+    id               int auto_increment
         primary key,
     created_at       timestamp                  not null,
     last_modified_at timestamp                  not null,
@@ -12,12 +12,12 @@ create table if not exists artist
 
 create table if not exists artist_alias
 (
-    id               bigint auto_increment
+    id               int auto_increment
         primary key,
     created_at       timestamp not null,
     last_modified_at timestamp not null,
-    alias_id         bigint    not null,
-    artist_id        bigint    not null,
+    alias_id         int       not null,
+    artist_id        int       not null,
     constraint uq_artist_alias_artist_id_alias_id
         unique (artist_id, alias_id),
     constraint fk_artist_alias_alias_id_artist
@@ -28,12 +28,12 @@ create table if not exists artist_alias
 
 create table if not exists artist_group
 (
-    id               bigint auto_increment
+    id               int auto_increment
         primary key,
     created_at       timestamp not null,
     last_modified_at timestamp not null,
-    artist_id        bigint    not null,
-    group_id         bigint    not null,
+    artist_id        int       not null,
+    group_id         int       not null,
     constraint uq_artist_group_artist_id_group_id
         unique (artist_id, group_id),
     constraint fk_artist_group_artist_id_artist
@@ -44,12 +44,12 @@ create table if not exists artist_group
 
 create table if not exists artist_member
 (
-    id               bigint auto_increment
+    id               int auto_increment
         primary key,
     created_at       timestamp not null,
     last_modified_at timestamp not null,
-    artist_id        bigint    not null,
-    member_id        bigint    not null,
+    artist_id        int       not null,
+    member_id        int       not null,
     constraint uq_artist_member_artist_id_member_id
         unique (artist_id, member_id),
     constraint fk_artist_member_artist_id_artist
@@ -60,13 +60,13 @@ create table if not exists artist_member
 
 create table if not exists artist_name_variation
 (
-    id               bigint auto_increment
+    id               int auto_increment
         primary key,
     created_at       timestamp                  not null,
     hash             int                        not null,
     last_modified_at timestamp                  not null,
     name_variation   varchar(2000) charset utf8 not null,
-    artist_id        bigint                     not null,
+    artist_id        int                        not null,
     constraint uq_artist_name_variation_artist_id_hash
         unique (artist_id, hash),
     constraint fk_artist_name_variation_artist_id_artist
@@ -75,13 +75,13 @@ create table if not exists artist_name_variation
 
 create table if not exists artist_url
 (
-    id               bigint auto_increment
+    id               int auto_increment
         primary key,
     created_at       timestamp                  not null,
     last_modified_at timestamp                  not null,
     hash             int                        not null,
     url              varchar(5000) charset utf8 not null,
-    artist_id        bigint                     not null,
+    artist_id        int                        not null,
     constraint uq_artist_url_artist_id_hash
         unique (artist_id, hash),
     constraint fk_artist_url_artist_id_artist
@@ -96,7 +96,7 @@ create table if not exists genre
 
 create table if not exists label
 (
-    id               bigint auto_increment
+    id               int auto_increment
         primary key,
     created_at       timestamp                 not null,
     last_modified_at timestamp                 not null,
@@ -108,12 +108,12 @@ create table if not exists label
 
 create table if not exists label_sub_label
 (
-    id               bigint auto_increment
+    id               int auto_increment
         primary key,
     created_at       timestamp not null,
     last_modified_at timestamp not null,
-    parent_label_id  bigint    not null,
-    sub_label_id     bigint    not null,
+    parent_label_id  int       not null,
+    sub_label_id     int       not null,
     constraint uq_label_sub_label_parent_label_id_sub_label_id
         unique (parent_label_id, sub_label_id),
     constraint fk_label_sub_label_parent_label_id_label
@@ -124,13 +124,13 @@ create table if not exists label_sub_label
 
 create table if not exists label_url
 (
-    id               bigint auto_increment
+    id               int auto_increment
         primary key,
     created_at       timestamp     not null,
     last_modified_at timestamp     not null,
     hash             int           not null,
     url              varchar(5000) not null,
-    label_id         bigint        not null,
+    label_id         int           not null,
     constraint uq_label_url_label_id_hash
         unique (label_id, hash),
     constraint fk_label_url_label_id_label
@@ -139,24 +139,24 @@ create table if not exists label_url
 
 create table if not exists master
 (
-    id               bigint auto_increment
+    id               int auto_increment
         primary key,
     created_at       timestamp                  not null,
     last_modified_at timestamp                  not null,
     data_quality     varchar(255) charset utf8  null,
     title            varchar(2000) charset utf8 null,
     year             smallint                   null,
-    main_release_id  bigint                     null
+    main_release_id  int                        null
 );
 
 create table if not exists master_artist
 (
-    id               bigint auto_increment
+    id               int auto_increment
         primary key,
     created_at       timestamp not null,
     last_modified_at timestamp not null,
-    artist_id        bigint    not null,
-    master_id        bigint    not null,
+    artist_id        int       not null,
+    master_id        int       not null,
     constraint uq_master_artist_master_id_artist_id
         unique (master_id, artist_id),
     constraint fk_master_artist_artist_id_artist
@@ -167,12 +167,12 @@ create table if not exists master_artist
 
 create table if not exists master_genre
 (
-    id               bigint auto_increment
+    id               int auto_increment
         primary key,
     created_at       timestamp                 not null,
     last_modified_at timestamp                 not null,
     genre            varchar(255) charset utf8 not null,
-    master_id        bigint                    not null,
+    master_id        int                       not null,
     constraint uq_master_genre_master_id_genre
         unique (master_id, genre),
     constraint fk_master_genre_genre_genre
@@ -183,7 +183,7 @@ create table if not exists master_genre
 
 create table if not exists master_video
 (
-    id               bigint auto_increment
+    id               int auto_increment
         primary key,
     created_at       timestamp                   not null,
     last_modified_at timestamp                   not null,
@@ -191,7 +191,7 @@ create table if not exists master_video
     description      varchar(15000) charset utf8 null,
     title            varchar(1000) charset utf8  null,
     url              varchar(1000) charset utf8  null,
-    master_id        bigint                      not null,
+    master_id        int                         not null,
     constraint uq_master_video_master_id_hash
         unique (master_id, hash),
     constraint fk_master_video_master_id_master
@@ -200,7 +200,7 @@ create table if not exists master_video
 
 create table if not exists release_item
 (
-    id                  bigint auto_increment
+    id                  int auto_increment
         primary key,
     created_at          timestamp                   not null,
     last_modified_at    timestamp                   not null,
@@ -210,7 +210,7 @@ create table if not exists release_item
     has_valid_month     bit                         null,
     has_valid_year      bit                         null,
     is_master           bit                         null,
-    master_id           bigint                      null,
+    master_id           int                         null,
     listed_release_date varchar(255) charset utf8   null,
     notes               text                        null,
     release_date        date                        null,
@@ -220,16 +220,16 @@ create table if not exists release_item
         foreign key (master_id) references master (id)
 );
 
-create table if not exists label_item_release
+create table if not exists label_release_item
 (
-    id                bigint auto_increment
+    id                int auto_increment
         primary key,
-    created_at        timestamp                 not null,
-    last_modified_at  timestamp                 not null,
-    category_notation varchar(255) charset utf8 null,
-    label_id          bigint                    not null,
-    release_item_id   bigint                    not null,
-    constraint uq_label_item_release_release_item_id_label_id
+    created_at        timestamp                  not null,
+    last_modified_at  timestamp                  not null,
+    category_notation varchar(1000) charset utf8 null,
+    label_id          int                        not null,
+    release_item_id   int                        not null,
+    constraint uq_label_release_item_release_item_id_label_id
         unique (release_item_id, label_id),
     constraint fk_label_release_label_id_label
         foreign key (label_id) references label (id),
@@ -243,12 +243,12 @@ alter table master
 
 create table if not exists release_item_artist
 (
-    id               bigint auto_increment
+    id               int auto_increment
         primary key,
     created_at       timestamp not null,
     last_modified_at timestamp not null,
-    artist_id        bigint    not null,
-    release_item_id  bigint    not null,
+    artist_id        int       not null,
+    release_item_id  int       not null,
     constraint uq_release_item_artist_release_item_id_artist_id
         unique (release_item_id, artist_id),
     constraint fk_release_item_artist_artist_id_artist
@@ -259,14 +259,14 @@ create table if not exists release_item_artist
 
 create table if not exists release_item_credited_artist
 (
-    id               bigint auto_increment
+    id               int auto_increment
         primary key,
     created_at       timestamp                   not null,
     last_modified_at timestamp                   not null,
     hash             int                         not null,
     role             varchar(20000) charset utf8 null,
-    artist_id        bigint                      not null,
-    release_item_id  bigint                      not null,
+    artist_id        int                         not null,
+    release_item_id  int                         not null,
     constraint uq_release_item_credited_artist_release_item_id_artist_id_hash
         unique (release_item_id, artist_id, hash),
     constraint fk_release_item_credited_artist_artist_id_artist
@@ -277,16 +277,16 @@ create table if not exists release_item_credited_artist
 
 create table if not exists release_item_format
 (
-    id               bigint auto_increment
+    id               int auto_increment
         primary key,
     created_at       timestamp                   not null,
     last_modified_at timestamp                   not null,
     hash             int                         not null,
     description      varchar(10000) charset utf8 null,
     name             varchar(255) charset utf8   null,
-    quantity         bigint                      null,
+    quantity         int                         null,
     text             varchar(5000) charset utf8  null,
-    release_item_id  bigint                      not null,
+    release_item_id  int                         not null,
     constraint uq_release_item_format_release_item_id_hash
         unique (release_item_id, hash),
     constraint fk_release_item_format_release_item_id_release_item
@@ -295,12 +295,12 @@ create table if not exists release_item_format
 
 create table if not exists release_item_genre
 (
-    id               bigint auto_increment
+    id               int auto_increment
         primary key,
     created_at       timestamp                 not null,
     last_modified_at timestamp                 not null,
     genre            varchar(255) charset utf8 not null,
-    release_item_id  bigint                    not null,
+    release_item_id  int                       not null,
     constraint uq_release_item_genre_release_item_id_genre
         unique (release_item_id, genre),
     constraint fk_release_item_genre_genre_genre
@@ -311,7 +311,7 @@ create table if not exists release_item_genre
 
 create table if not exists release_item_identifier
 (
-    id               bigint auto_increment
+    id               int auto_increment
         primary key,
     created_at       timestamp not null,
     last_modified_at timestamp not null,
@@ -319,7 +319,7 @@ create table if not exists release_item_identifier
     description      longtext  null,
     type             longtext  null,
     value            longtext  null,
-    release_item_id  bigint    not null,
+    release_item_id  int       not null,
     constraint uq_release_item_identifier_release_item_id_hash
         unique (release_item_id, hash),
     constraint fk_release_item_identifier_release_item_id_release_item
@@ -328,13 +328,13 @@ create table if not exists release_item_identifier
 
 create table if not exists release_item_image
 (
-    id               bigint auto_increment
+    id               int auto_increment
         primary key,
     created_at       timestamp not null,
     last_modified_at timestamp not null,
     hash             int       not null,
     file_name        longtext  null,
-    release_item_id  bigint    not null,
+    release_item_id  int       not null,
     constraint uq_release_item_image_release_item_id_hash
         unique (release_item_id, hash),
     constraint fk_release_item_image_release_item_id_release_item
@@ -343,7 +343,7 @@ create table if not exists release_item_image
 
 create table if not exists release_item_track
 (
-    id               bigint auto_increment
+    id               int auto_increment
         primary key,
     created_at       timestamp not null,
     last_modified_at timestamp not null,
@@ -351,7 +351,7 @@ create table if not exists release_item_track
     duration         longtext  null,
     position         longtext  null,
     title            longtext  null,
-    release_item_id  bigint    not null,
+    release_item_id  int       not null,
     constraint uq_release_item_track_release_item_id_hash
         unique (release_item_id, hash),
     constraint fk_release_item_track_release_item_id_release_item
@@ -360,7 +360,7 @@ create table if not exists release_item_track
 
 create table if not exists release_item_video
 (
-    id               bigint auto_increment
+    id               int auto_increment
         primary key,
     created_at       timestamp not null,
     last_modified_at timestamp not null,
@@ -368,7 +368,7 @@ create table if not exists release_item_video
     description      longtext  null,
     title            longtext  null,
     url              longtext  null,
-    release_item_id  bigint    not null,
+    release_item_id  int       not null,
     constraint uq_release_item_video_release_item_id_hash
         unique (release_item_id, hash),
     constraint fk_release_item_video_release_item_id_release_item
@@ -377,14 +377,14 @@ create table if not exists release_item_video
 
 create table if not exists release_item_work
 (
-    id               bigint auto_increment
+    id               int auto_increment
         primary key,
     created_at       timestamp                  not null,
     last_modified_at timestamp                  not null,
     hash             int                        not null,
     work             varchar(5000) charset utf8 null,
-    label_id         bigint                     not null,
-    release_item_id  bigint                     not null,
+    label_id         int                        not null,
+    release_item_id  int                        not null,
     constraint uq_release_item_work_release_item_id_label_id_hash
         unique (release_item_id, label_id, hash),
     constraint fk_release_item_work_label_id_label
@@ -401,11 +401,11 @@ create table if not exists style
 
 create table if not exists master_style
 (
-    id               bigint auto_increment
+    id               int auto_increment
         primary key,
     created_at       timestamp                 not null,
     last_modified_at timestamp                 not null,
-    master_id        bigint                    not null,
+    master_id        int                       not null,
     style            varchar(255) charset utf8 not null,
     constraint uq_master_style_master_id_style
         unique (master_id, style),
@@ -417,11 +417,11 @@ create table if not exists master_style
 
 create table if not exists release_item_style
 (
-    id               bigint auto_increment
+    id               int auto_increment
         primary key,
     created_at       timestamp                 not null,
     last_modified_at timestamp                 not null,
-    release_item_id  bigint                    not null,
+    release_item_id  int                       not null,
     style            varchar(255) charset utf8 not null,
     constraint uq_release_item_style_release_item_id_style
         unique (release_item_id, style),

--- a/src/main/resources/postgresql-init.sql
+++ b/src/main/resources/postgresql-init.sql
@@ -81,21 +81,21 @@ create table if not exists public.release_item_track
         unique (release_item_id, hash)
 );
 
-create table if not exists public.label_item_release
+create table if not exists public.label_release_item
 (
     id                serial
-        constraint pk_label_item_release
+        constraint pk_label_release_item
             primary key,
     created_at        timestamp not null,
     last_modified_at  timestamp not null,
-    category_notation varchar(255),
+    category_notation varchar(1000),
     label_id          integer   not null
         constraint fk_label_release_label_id_label
             references public.label,
     release_item_id   integer   not null
         constraint fk_label_release_release_item_id_release_item
             references public.release_item,
-    constraint uq_label_item_release_release_item_id_label_id
+    constraint uq_label_release_item_release_item_id_label_id
         unique (release_item_id, label_id)
 );
 


### PR DESCRIPTION
found some of the category notations are well over 500.