### PR TITLE
chore: update repository ownership metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ jOOQ-generated schema classes shared by DSUB OpenDiscogs data services.
 This is an independent DSUB project. It is not affiliated with or endorsed by
 Discogs.
 
-[discogs-batch](https://github.com/echovisionlab/discogs-batch)
+[OpenDiscogs Batch](https://github.com/dsub-io/open-discogs-batch)
 
 ## Dependency
 

--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,7 @@ publishing {
             pom {
                 name = 'DSUB OpenDiscogs jOOQ'
                 description = 'jOOQ-generated schema classes for DSUB OpenDiscogs data services.'
-                url = 'https://github.com/state303/open-discogs-jooq'
+                url = 'https://github.com/dsub-io/open-discogs-jooq'
                 inceptionYear = '2021'
 
                 licenses {
@@ -90,15 +90,15 @@ publishing {
                 }
 
                 scm {
-                    connection = 'scm:git:https://github.com/state303/open-discogs-jooq.git'
-                    developerConnection = 'scm:git:ssh://git@github.com/state303/open-discogs-jooq.git'
-                    url = 'https://github.com/state303/open-discogs-jooq'
+                    connection = 'scm:git:https://github.com/dsub-io/open-discogs-jooq.git'
+                    developerConnection = 'scm:git:ssh://git@github.com/dsub-io/open-discogs-jooq.git'
+                    url = 'https://github.com/dsub-io/open-discogs-jooq'
                     tag = "v${project.version}"
                 }
 
                 issueManagement {
                     system = 'GitHub'
-                    url = 'https://github.com/state303/open-discogs-jooq/issues'
+                    url = 'https://github.com/dsub-io/open-discogs-jooq/issues'
                 }
             }
         }


### PR DESCRIPTION
## What changed

- update project, SCM, and issue URLs to `dsub-io/open-discogs-jooq`
- point the related Batch project link to `dsub-io/open-discogs-batch`

## Why

Both OpenDiscogs repositories now belong to the `dsub-io` organization, so published Maven metadata and documentation must identify the new canonical locations.

## Impact

Artifact coordinates and generated jOOQ APIs are unchanged. Future Maven Central releases will contain the new canonical project and SCM URLs.

## Checks

- `git diff --check`
- `./gradlew clean generatePomFileForMavenJavaPublication -PreleaseVersion=0.0.4 --no-daemon` using Eclipse Temurin 16
- verified generated POM URLs under `build/publications/mavenJava/pom-default.xml`
