### PR TITLE
fix: allow reissued dump paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ Java and Go the same content fingerprint and skip/force semantics.
 Application-specific Spring Batch metadata and query logic do not belong to
 this module.
 
+Dump content versions are unique by date, entity type, and SHA-256. ETag is
+indexed for lookup but is not unique because a versioned source path can be
+reissued with different bytes.
+
 By default an importer skips a manifest that already has a successful run.
 Failed or incomplete runs remain retryable, and an explicit force option may
 reprocess a successful manifest. Forced reprocessing must still converge on the

--- a/schema/contracts/import-manifest-v1.md
+++ b/schema/contracts/import-manifest-v1.md
@@ -22,7 +22,9 @@ To compute `manifest_sha256`:
 4. compute the lowercase hexadecimal SHA-256 of the complete preimage.
 
 URI, ETag, byte size, processor, and processor version are retained as
-provenance but are not part of content identity.
+provenance but are not part of content identity. ETag is deliberately not
+unique because the current HTML source uses the versioned file path as its
+fallback identifier and upstream may reissue that path with different bytes.
 
 Before starting work, an importer checks for a successful run with the same
 manifest fingerprint. It skips that manifest unless force was explicitly

--- a/schema/embed_test.go
+++ b/schema/embed_test.go
@@ -22,6 +22,7 @@ func TestMigrations(t *testing.T) {
 		"V001__initial_schema.sql",
 		"V002__discogs_dump_catalog.sql",
 		"V003__discogs_import_history.sql",
+		"V004__allow_reissued_dump_paths.sql",
 	}
 	if len(entries) != len(want) {
 		t.Fatalf("migration count = %d, want %d", len(entries), len(want))

--- a/schema/migrations/V004__allow_reissued_dump_paths.sql
+++ b/schema/migrations/V004__allow_reissued_dump_paths.sql
@@ -1,0 +1,5 @@
+alter table public.discogs_dump
+    drop constraint if exists uq_discogs_dump_etag;
+
+create index if not exists ix_discogs_dump_etag
+    on public.discogs_dump (etag);


### PR DESCRIPTION
## What changed

- remove the uniqueness requirement from dump ETag values
- keep ETag indexed for provenance lookup
- retain date, entity type, and SHA-256 as dump content identity
- document why a versioned HTML path may identify multiple upstream byte versions

## Why

The current HTML index does not expose an object ETag, so the importer uses the versioned file path as its fallback stable ID. Upstream can reissue the same path with different bytes and a different checksum. Rejecting the second version would lose provenance and prevent a corrected same-date import.

## Validation

- `actionlint`
- `shellcheck scripts/*.sh`
- `scripts/verify-generated-models.sh`
- `go test ./...`
- `./gradlew clean build --no-daemon --warning-mode=fail` with Temurin 21
- fresh PostgreSQL 18 migrations accepted two rows with the same ETag and different SHA-256 values
