### PR TITLE
fix: allow independent entity dump dates

### DIFF
--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -48,7 +48,6 @@ func Canonical(dumps []Dump) ([]byte, error) {
 
 	normalized := make([]Dump, len(dumps))
 	seen := make(map[string]struct{}, len(dumps))
-	var dumpDate string
 	for index, dump := range dumps {
 		entityType := strings.ToLower(dump.EntityType)
 		if _, known := knownEntityTypes[entityType]; !known {
@@ -59,16 +58,9 @@ func Canonical(dumps []Dump) ([]byte, error) {
 		}
 		seen[entityType] = struct{}{}
 
-		date := dump.DumpDate.Format("2006-01-02")
 		if dump.DumpDate.IsZero() {
 			return nil, fmt.Errorf("dump date is required for %q", entityType)
 		}
-		if dumpDate == "" {
-			dumpDate = date
-		} else if dumpDate != date {
-			return nil, errors.New("all dumps must use the same dump date")
-		}
-
 		if !checksumPattern.MatchString(dump.ChecksumSHA256) {
 			return nil, fmt.Errorf("invalid SHA-256 for %q", entityType)
 		}

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -64,14 +64,6 @@ func TestCanonicalRejectsAmbiguousManifests(t *testing.T) {
 	tests := map[string][]Dump{
 		"empty":          nil,
 		"duplicate type": {valid, valid},
-		"mixed dates": {
-			valid,
-			{
-				EntityType:     "label",
-				DumpDate:       date.AddDate(0, 0, 1),
-				ChecksumSHA256: strings.Repeat("b", 64),
-			},
-		},
 		"invalid checksum": {{
 			EntityType:     "artist",
 			DumpDate:       date,
@@ -91,5 +83,32 @@ func TestCanonicalRejectsAmbiguousManifests(t *testing.T) {
 				t.Fatal("Canonical() error = nil")
 			}
 		})
+	}
+}
+
+func TestCanonicalAllowsIndependentEntityDates(t *testing.T) {
+	t.Parallel()
+
+	canonical, err := Canonical([]Dump{
+		{
+			EntityType:     "release",
+			DumpDate:       time.Date(2026, time.July, 2, 0, 0, 0, 0, time.UTC),
+			ChecksumSHA256: strings.Repeat("b", 64),
+		},
+		{
+			EntityType:     "artist",
+			DumpDate:       time.Date(2026, time.July, 1, 0, 0, 0, 0, time.UTC),
+			ChecksumSHA256: strings.Repeat("a", 64),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := "open-discogs-manifest/v1\n" +
+		"artist\x002026-07-01\x00" + strings.Repeat("a", 64) + "\n" +
+		"release\x002026-07-02\x00" + strings.Repeat("b", 64) + "\n"
+	if string(canonical) != want {
+		t.Fatalf("Canonical() = %q, want %q", string(canonical), want)
 	}
 }

--- a/schema/contracts/import-manifest-v1.md
+++ b/schema/contracts/import-manifest-v1.md
@@ -4,8 +4,9 @@ An import is identified by the bytes of the selected dumps, not by their
 download location.
 
 The manifest contains one entry per selected entity type. Entity types are
-limited to `artist`, `label`, `master`, and `release`, may appear only once, and
-must all use the same dump date. A normal full import requires all four types.
+limited to `artist`, `label`, `master`, and `release`, and may appear only once.
+Every entry carries its own dump date, so an entity absent from one publication
+can use a different dated dump. A normal full import requires all four types.
 A deliberately scoped import may contain a dependency-complete subset.
 
 To compute `manifest_sha256`:

--- a/src/main/java/io/dsub/opendiscogs/model/manifest/ImportManifest.java
+++ b/src/main/java/io/dsub/opendiscogs/model/manifest/ImportManifest.java
@@ -55,7 +55,6 @@ public final class ImportManifest {
 
     List<Dump> normalized = new ArrayList<>(dumps.size());
     Set<String> seen = new HashSet<>();
-    LocalDate commonDate = null;
     for (Dump dump : dumps) {
       if (dump == null || dump.entityType() == null || dump.dumpDate() == null
           || dump.checksumSha256() == null) {
@@ -67,11 +66,6 @@ public final class ImportManifest {
       }
       if (!seen.add(entityType)) {
         throw new IllegalArgumentException("duplicate entity type " + entityType);
-      }
-      if (commonDate == null) {
-        commonDate = dump.dumpDate();
-      } else if (!commonDate.equals(dump.dumpDate())) {
-        throw new IllegalArgumentException("all dumps must use the same dump date");
       }
       if (!CHECKSUM_PATTERN.matcher(dump.checksumSha256()).matches()) {
         throw new IllegalArgumentException("invalid SHA-256 for " + entityType);

--- a/src/test/java/io/dsub/opendiscogs/model/manifest/ImportManifestTest.java
+++ b/src/test/java/io/dsub/opendiscogs/model/manifest/ImportManifestTest.java
@@ -56,15 +56,26 @@ class ImportManifestTest {
   }
 
   @Test
-  void rejectsMixedDates() {
-    assertThrows(
-        IllegalArgumentException.class,
-        () ->
-            ImportManifest.fingerprint(
+  void allowsIndependentEntityDates() {
+    String canonical =
+        new String(
+            ImportManifest.canonical(
                 List.of(
                     new ImportManifest.Dump(
-                        "artist", LocalDate.of(2026, 7, 1), "a".repeat(64)),
+                        "release", LocalDate.of(2026, 7, 2), "b".repeat(64)),
                     new ImportManifest.Dump(
-                        "label", LocalDate.of(2026, 7, 2), "b".repeat(64)))));
+                        "artist", LocalDate.of(2026, 7, 1), "a".repeat(64)))),
+            StandardCharsets.UTF_8);
+
+    assertEquals(
+        "open-discogs-manifest/v1\n"
+            + "artist\0"
+            + "2026-07-01\0"
+            + "a".repeat(64)
+            + "\nrelease\0"
+            + "2026-07-02\0"
+            + "b".repeat(64)
+            + "\n",
+        canonical);
   }
 }


### PR DESCRIPTION
## Summary
- allow each entity in an import manifest to carry its own dump date
- preserve deterministic cross-language fingerprinting and entity uniqueness
- document and test missing-domain monthly publication handling

## Validation
- `go test ./...`
- `JAVA_HOME=$HOME/.sdkman/candidates/java/21.0.11-tem ./gradlew clean build --no-daemon --warning-mode=fail`