### PR TITLE
docs: use public attribution

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2021-2026 Seunghyun Bae / DSUB
+   Copyright 2021-2026 state303 / DSUB
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,7 +1,7 @@
 DSUB OpenDiscogs Model
-Copyright 2021-2026 Seunghyun Bae / DSUB
+Copyright 2021-2026 state303 / DSUB
 
-This product includes software developed by Seunghyun Bae for DSUB
+This product includes software developed by state303 for DSUB
 (https://www.dsub.io).
 
 This project is independent and is not affiliated with or endorsed by Discogs.


### PR DESCRIPTION
## Summary

- replace the personal name in Apache license attribution with the public `state303` identity
- keep the DSUB organization attribution and existing license terms unchanged

## Validation

- `git diff --check`
- GitHub token-pattern scan across all refs: clean
- GitHub secret scanning alerts: 0

This documentation-only commit does not trigger a model release.