### PR TITLE
ci: prevent non-release commits from publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,18 @@ jobs:
 
       - uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
 
+      - name: Verify release policy
+        shell: bash
+        run: |
+          set -euo pipefail
+          jq empty release-please-config.json
+          for type in build chore ci docs refactor style test; do
+            jq -e \
+              --arg type "$type" \
+              'any(.["changelog-sections"][]; .type == $type and .hidden == true)' \
+              release-please-config.json >/dev/null
+          done
+
       - name: Verify generated Go models
         run: scripts/verify-generated-models.sh
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,19 +8,23 @@
   "changelog-sections": [
     {
       "type": "build",
-      "section": "Build System"
+      "section": "Build System",
+      "hidden": true
     },
     {
       "type": "chore",
-      "section": "Maintenance"
+      "section": "Maintenance",
+      "hidden": true
     },
     {
       "type": "ci",
-      "section": "Continuous Integration"
+      "section": "Continuous Integration",
+      "hidden": true
     },
     {
       "type": "docs",
-      "section": "Documentation"
+      "section": "Documentation",
+      "hidden": true
     },
     {
       "type": "feat",
@@ -36,7 +40,8 @@
     },
     {
       "type": "refactor",
-      "section": "Code Refactoring"
+      "section": "Code Refactoring",
+      "hidden": true
     },
     {
       "type": "revert",
@@ -44,11 +49,13 @@
     },
     {
       "type": "style",
-      "section": "Styles"
+      "section": "Styles",
+      "hidden": true
     },
     {
       "type": "test",
-      "section": "Tests"
+      "section": "Tests",
+      "hidden": true
     }
   ],
   "packages": {


### PR DESCRIPTION
## Summary
- mark documentation, CI, build, maintenance, refactor, style, and test commits as hidden Release Please sections
- enforce the non-release commit policy in CI
- preserve releases for feature, fix, performance, revert, and breaking changes

## Validation
- `jq` release-policy checks
- `actionlint .github/workflows/*.yml`
- `scripts/verify-generated-models.sh`
- `go test ./...`
- Java 21 `./gradlew clean build --no-daemon --warning-mode=fail`

## Incident
Release Please opened #33 after a docs-only merge. That release PR must be closed and must not be published.
