### PR TITLE
feat: add durable import progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,13 @@ source. The Java jOOQ classes and Go structs are generated from a PostgreSQL
 database created from those ordered migrations.
 
 The schema includes the OpenDiscogs catalog tables, immutable dump provenance,
-and import-run history. The shared
+append-only import-run identity, and bounded progress that becomes historical
+when a run completes. The shared
 [`import-manifest-v1`](schema/contracts/import-manifest-v1.md) contract gives
 Java and Go the same content fingerprint and skip/force semantics.
+The bounded [`import-progress-v1`](schema/contracts/import-progress-v1.md)
+contract records at most one progress row per selected entity and run so a
+retry can resume committed chunks without progress growing with dump size.
 Application-specific Spring Batch metadata and query logic do not belong to
 this module.
 
@@ -78,6 +82,10 @@ Failed or incomplete runs remain retryable, and an explicit force option may
 reprocess a successful manifest. Forced reprocessing must still converge on the
 same normalized business state. The `discogs_import_checkpoint` view exposes
 the last successfully applied dump date and provenance for each entity type.
+Progress advances in the same transaction as a root entity's complete
+canonical relation set. A retry may resume only from an identical manifest,
+processor, processor version, entity type, and dump, while forced imports
+always start from zero.
 Per-entity PostgreSQL advisory locks allow disjoint imports to run concurrently
 while rejecting overlapping writers. Older dumps are rejected unless a
 separate, audited downgrade option is explicitly requested.

--- a/model/schema.gen.go
+++ b/model/schema.gen.go
@@ -144,6 +144,7 @@ type DiscogsImportCheckpoint struct {
 	Processor        *string    `db:"processor" json:"processor" gorm:"column:processor"`
 	ProcessorVersion *string    `db:"processor_version" json:"processor_version" gorm:"column:processor_version"`
 	AppliedAt        *time.Time `db:"applied_at" json:"applied_at" gorm:"column:applied_at"`
+	ResumedFromRunID *int64     `db:"resumed_from_run_id" json:"resumed_from_run_id" gorm:"column:resumed_from_run_id"`
 }
 
 // TableName returns the PostgreSQL table represented by DiscogsImportCheckpoint.
@@ -162,6 +163,7 @@ type DiscogsImportRun struct {
 	Processor               string     `db:"processor" json:"processor" gorm:"column:processor"`
 	ProcessorVersion        string     `db:"processor_version" json:"processor_version" gorm:"column:processor_version"`
 	FailureMessage          *string    `db:"failure_message" json:"failure_message" gorm:"column:failure_message"`
+	ResumedFromRunID        *int64     `db:"resumed_from_run_id" json:"resumed_from_run_id" gorm:"column:resumed_from_run_id"`
 }
 
 // TableName returns the PostgreSQL table represented by DiscogsImportRun.
@@ -169,9 +171,12 @@ func (DiscogsImportRun) TableName() string { return "discogs_import_run" }
 
 // DiscogsImportRunDump represents a row in discogs_import_run_dump.
 type DiscogsImportRunDump struct {
-	ImportRunID int64  `db:"import_run_id" json:"import_run_id" gorm:"column:import_run_id;primaryKey"`
-	EntityType  string `db:"entity_type" json:"entity_type" gorm:"column:entity_type;primaryKey"`
-	DumpID      int64  `db:"dump_id" json:"dump_id" gorm:"column:dump_id"`
+	ImportRunID    int64      `db:"import_run_id" json:"import_run_id" gorm:"column:import_run_id;primaryKey"`
+	EntityType     string     `db:"entity_type" json:"entity_type" gorm:"column:entity_type;primaryKey"`
+	DumpID         int64      `db:"dump_id" json:"dump_id" gorm:"column:dump_id"`
+	ProcessedItems int64      `db:"processed_items" json:"processed_items" gorm:"column:processed_items"`
+	LastProgressAt *time.Time `db:"last_progress_at" json:"last_progress_at" gorm:"column:last_progress_at"`
+	CompletedAt    *time.Time `db:"completed_at" json:"completed_at" gorm:"column:completed_at"`
 }
 
 // TableName returns the PostgreSQL table represented by DiscogsImportRunDump.

--- a/model/schema_test.go
+++ b/model/schema_test.go
@@ -1,6 +1,9 @@
 package model
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 func TestTableNames(t *testing.T) {
 	t.Parallel()
@@ -30,5 +33,28 @@ func TestTableNames(t *testing.T) {
 		if _, exists := seen[required]; !exists {
 			t.Errorf("required table %q is missing", required)
 		}
+	}
+}
+
+func TestImportProgressModels(t *testing.T) {
+	t.Parallel()
+
+	resumedFromRunID := int64(11)
+	progressedAt := time.Date(2026, time.August, 10, 0, 0, 0, 0, time.UTC)
+	run := DiscogsImportRun{ResumedFromRunID: &resumedFromRunID}
+	dump := DiscogsImportRunDump{
+		ImportRunID: 12, EntityType: "release", DumpID: 13,
+		ProcessedItems: 14, LastProgressAt: &progressedAt, CompletedAt: &progressedAt,
+	}
+	checkpoint := DiscogsImportCheckpoint{ResumedFromRunID: &resumedFromRunID}
+
+	if run.ResumedFromRunID == nil || *run.ResumedFromRunID != resumedFromRunID {
+		t.Fatalf("resumed run ID = %v", run.ResumedFromRunID)
+	}
+	if dump.ProcessedItems != 14 || dump.LastProgressAt == nil || dump.CompletedAt == nil {
+		t.Fatalf("import progress = %+v", dump)
+	}
+	if checkpoint.ResumedFromRunID == nil || *checkpoint.ResumedFromRunID != resumedFromRunID {
+		t.Fatalf("checkpoint resumed run ID = %v", checkpoint.ResumedFromRunID)
 	}
 }

--- a/schema/contracts/import-manifest-v1.md
+++ b/schema/contracts/import-manifest-v1.md
@@ -52,6 +52,11 @@ completed. A failed or interrupted run remains retryable. Reprocessing a
 manifest with force must leave the same normalized business rows as the first
 successful import.
 
+The adjacent [`import-progress-v1`](import-progress-v1.md) contract defines
+when committed entity progress may be resumed by a later run. Progress never
+changes manifest identity or permits a successful manifest to be skipped under
+different content.
+
 The `discogs_import_checkpoint` view exposes the last successfully applied dump
 for each entity type. It is derived from immutable run history so checkpoint
 dates cannot drift away from the run and dump that produced them.

--- a/schema/contracts/import-progress-v1.md
+++ b/schema/contracts/import-progress-v1.md
@@ -1,0 +1,33 @@
+# Import progress v1
+
+Durable progress is recorded once per import run and entity type in
+`discogs_import_run_dump`. It does not create one database row per source item
+or chunk.
+
+`processed_items` is the number of root XML elements, in source order, whose
+canonical entity and complete relation set have committed. An importer advances
+this value in the same transaction as the corresponding catalog writes. It
+must never advance progress before those writes commit or process chunks out of
+source order.
+
+`last_progress_at` records the last committed progress update. `completed_at`
+is set only after the importer reaches a valid end of the entity stream and all
+catalog writes have committed. An import run may become `success` only when
+every selected `discogs_import_run_dump` row has `completed_at` set.
+
+A retry creates a new import run. When `force_requested` is false, it may copy
+progress from the most recent failed or abandoned run only when all of the
+following values match exactly:
+
+- manifest SHA-256;
+- processor name and processor version;
+- entity type and dump ID.
+
+The new run records that source run in `resumed_from_run_id`. A forced import
+starts every entity at zero and does not resume prior progress. Importers may
+re-read or skip already committed source elements while locating the resume
+position, but they must not rewrite or recount them as new progress.
+
+The progress contract assumes each committed root entity has converged to the
+exact relation set represented by the dump. Repeating a chunk after a rollback
+must therefore produce the same normalized business state.

--- a/schema/embed_test.go
+++ b/schema/embed_test.go
@@ -23,6 +23,7 @@ func TestMigrations(t *testing.T) {
 		"V002__discogs_dump_catalog.sql",
 		"V003__discogs_import_history.sql",
 		"V004__allow_reissued_dump_paths.sql",
+		"V005__durable_import_progress.sql",
 	}
 	if len(entries) != len(want) {
 		t.Fatalf("migration count = %d, want %d", len(entries), len(want))

--- a/schema/migrations/V005__durable_import_progress.sql
+++ b/schema/migrations/V005__durable_import_progress.sql
@@ -1,0 +1,42 @@
+alter table public.discogs_import_run
+    add column resumed_from_run_id bigint
+        constraint fk_discogs_import_run_resumed_from_run_id
+            references public.discogs_import_run;
+
+alter table public.discogs_import_run
+    add constraint ck_discogs_import_run_not_self_resumed
+        check (resumed_from_run_id is null or resumed_from_run_id <> id);
+
+alter table public.discogs_import_run_dump
+    add column processed_items bigint not null default 0,
+    add column last_progress_at timestamp,
+    add column completed_at timestamp,
+    add constraint ck_discogs_import_run_dump_processed_items
+        check (processed_items >= 0),
+    add constraint ck_discogs_import_run_dump_completion
+        check (completed_at is null or last_progress_at is not null);
+
+create or replace view public.discogs_import_checkpoint as
+select distinct on (run_dump.entity_type)
+    run_dump.entity_type,
+    dump.dump_date,
+    dump.checksum_sha256,
+    dump.size_bytes,
+    dump.etag,
+    dump.uri,
+    import_run.id as import_run_id,
+    import_run.processor,
+    import_run.processor_version,
+    import_run.completed_at as applied_at,
+    import_run.resumed_from_run_id
+from public.discogs_import_run import_run
+join public.discogs_import_run_dump run_dump
+    on run_dump.import_run_id = import_run.id
+join public.discogs_dump dump
+    on dump.id = run_dump.dump_id
+   and dump.entity_type = run_dump.entity_type
+where import_run.status = 'success'
+order by
+    run_dump.entity_type,
+    import_run.completed_at desc,
+    import_run.id desc;

--- a/scripts/generate-go-models.sh
+++ b/scripts/generate-go-models.sh
@@ -5,21 +5,52 @@ repository_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 temporary_dir="$(mktemp -d)"
 container_name="open-discogs-model-generator-$$"
 catalog_path="$temporary_dir/catalog.tsv"
+postgres_image="postgres:18.4-alpine"
+image_was_present=false
 
 cleanup() {
+  case "$container_name" in
+    open-discogs-model-generator-[0-9]*) ;;
+    *)
+      printf 'Refusing to clean unexpected container name: %s\n' "$container_name" >&2
+      return 1
+      ;;
+  esac
   docker rm --force "$container_name" >/dev/null 2>&1 || true
-  rm -r "$temporary_dir"
+  if docker ps -a --filter "name=^/${container_name}$" --format '{{.Names}}' | grep -q .; then
+    printf 'Generator container cleanup failed: %s\n' "$container_name" >&2
+    return 1
+  fi
+  if [[ "$image_was_present" == false ]]; then
+    docker image rm "$postgres_image" >/dev/null 2>&1 || true
+  fi
+  rm -r -- "$temporary_dir"
 }
 trap cleanup EXIT
 
+if docker image inspect "$postgres_image" >/dev/null 2>&1; then
+  image_was_present=true
+fi
+
 docker run \
   --detach \
-  --rm \
   --name "$container_name" \
+  --label io.dsub.test-owner=open-discogs-model \
+  --tmpfs /var/lib/postgresql:rw,noexec,nosuid,size=512m \
   --env POSTGRES_DB=modelgen \
   --env POSTGRES_PASSWORD=modelgen \
   --env POSTGRES_USER=modelgen \
-  postgres:18.4-alpine >/dev/null
+  "$postgres_image" >/dev/null
+
+volume_mounts="$(
+  docker inspect \
+    --format '{{range .Mounts}}{{if eq .Type "volume"}}{{println .Name}}{{end}}{{end}}' \
+    "$container_name"
+)"
+if [[ -n "$volume_mounts" ]]; then
+  printf 'Generator unexpectedly created Docker volumes: %s\n' "$volume_mounts" >&2
+  exit 1
+fi
 
 for attempt in {1..30}; do
   if docker exec "$container_name" \

--- a/scripts/verify-generated-models.sh
+++ b/scripts/verify-generated-models.sh
@@ -2,6 +2,12 @@
 set -euo pipefail
 
 repository_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+generated_model="$repository_root/model/schema.gen.go"
+before_hash="$(git hash-object "$generated_model")"
 
 "$repository_root/scripts/generate-go-models.sh"
-git -C "$repository_root" diff --exit-code -- model/schema.gen.go
+after_hash="$(git hash-object "$generated_model")"
+if [[ "$before_hash" != "$after_hash" ]]; then
+  printf 'Generated Go model was stale; regenerate and commit model/schema.gen.go.\n' >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- add bounded per-run, per-entity progress to the canonical schema
- define safe resume rules for identical manifests and processor versions
- expose resume provenance through the import checkpoint view
- prevent model-generation containers and volumes from being left behind

## Scale and performance
- progress remains bounded to the existing import-run entity rows: at most four rows per run
- no catalog-table backfill, full-data rewrite, permanent staging table, or per-chunk history table is introduced
- this schema-only change does not alter the import data path, so throughput measurements belong to the follow-up Batch implementation

## Verification
- scripts/verify-generated-models.sh
- go test ./...
- ./gradlew clean build --no-daemon --warning-mode=fail
- generated PostgreSQL containers and volumes verified removed