### PR TITLE
docs: clarify import recovery fencing

### DIFF
--- a/schema/contracts/import-manifest-v1.md
+++ b/schema/contracts/import-manifest-v1.md
@@ -28,9 +28,13 @@ unique because the current HTML source uses the versioned file path as its
 fallback identifier and upstream may reissue that path with different bytes.
 
 Before starting work, an importer checks for a successful run with the same
-manifest fingerprint. It skips that manifest unless force was explicitly
-requested. Failed and running records never authorize a skip. At most one
-running import of a manifest may exist at a time.
+manifest fingerprint. It may skip only when every dump in that successful run
+is still the current checkpoint for its entity and no failed or abandoned run
+completed for those entities after the checkpoints were applied. A later
+failed run may have committed only part of another dump, so historical success
+alone does not prove that the current business rows still represent that
+manifest. Force always disables the skip. At most one running import of a
+manifest may exist at a time.
 
 Importers also serialize writes per entity type with PostgreSQL session
 advisory locks. The shared two-key namespace is `1329876273`; entity keys are
@@ -46,6 +50,12 @@ to close the preflight race. A candidate whose dump date predates that entity's
 checkpoint is rejected. `force` does not bypass this rule. An explicit
 `allow_downgrade` option is required and is recorded on the run when an
 operator intentionally applies older data.
+
+Each committing unit fences against its owning run while that run is still
+`running`. Marking an abandoned run `failed` must serialize with in-flight
+units: a unit fenced first may commit atomically and enter the resume ledger;
+otherwise its business writes and progress roll back. A delayed worker must
+never commit after its run has become `failed`.
 
 An importer marks a run successful only after every requested entity type has
 completed. A failed or interrupted run remains retryable. Reprocessing a

--- a/schema/contracts/import-progress-v1.md
+++ b/schema/contracts/import-progress-v1.md
@@ -30,18 +30,26 @@ following values match exactly:
 
 - manifest SHA-256;
 - processor name and processor version;
-- entity type and dump ID.
+- entity type and dump ID;
 - chunk size.
+
+Progress is not resumable if a newer successful checkpoint has overwritten any
+selected entity with a different dump, processor, or processor version. This
+check is relative to the failed run's completion time: an older checkpoint does
+not invalidate chunks that the failed run committed afterward.
 
 The new run records that source run in `resumed_from_run_id` and copies its
 summary and chunk ledger atomically. A forced import starts every entity at zero
 and does not resume prior progress. Importers may re-read committed source
 elements while locating ranges, but they must not rewrite or recount them.
 
-Once a retry owns a copied ledger, older failed-run chunk rows may be pruned.
-Chunk rows for a successful run may also be pruned because successful manifest
-identity, totals, and completion remain in the run history. Pruning must never
-remove the only ledger from which an unfinished run can resume.
+Once a retry owns a copied ledger, the source rows are transferred atomically.
+Other failed-run rows may be pruned only when every entity/dump pair is the
+current successful checkpoint produced by the same processor version;
+historical success is insufficient. Chunk rows for a successful run may also
+be pruned because successful manifest identity, totals, and completion remain
+in the run history. Pruning must never remove the only valid ledger from which
+an unfinished run can resume.
 
 The progress contract assumes each committed root entity has converged to the
 exact relation set represented by the dump. Repeating a chunk after a rollback


### PR DESCRIPTION
## Summary
- require current checkpoints and a clean post-checkpoint history before manifest skip
- define database fencing for delayed workers
- prevent resume and pruning from relying on historical or overwritten progress

## Verification
- `scripts/verify-generated-models.sh`
- `go test ./...`
- `./gradlew clean build --no-daemon --warning-mode=fail`

Documentation-only contract clarification; no release artifact is required.