### PR TITLE
fix: lock import reference dependencies

### DIFF
--- a/manifest/execution.go
+++ b/manifest/execution.go
@@ -17,6 +17,13 @@ var entityLockKeys = map[string]int32{
 	"release": 4,
 }
 
+var entityLockDependencies = map[string][]string{
+	"artist":  {"artist"},
+	"label":   {"label"},
+	"master":  {"artist", "master"},
+	"release": {"artist", "label", "master", "release"},
+}
+
 // EntityLockKey returns the stable second PostgreSQL advisory lock key.
 func EntityLockKey(entityType string) (int32, error) {
 	key, found := entityLockKeys[strings.ToLower(entityType)]
@@ -43,6 +50,19 @@ func OrderedEntityTypes(entityTypes []string) ([]string, error) {
 	}
 	sort.Strings(ordered)
 	return ordered, nil
+}
+
+// RequiredLockEntityTypes expands selected entities to every read and write dependency lock.
+func RequiredLockEntityTypes(selectedEntityTypes []string) ([]string, error) {
+	selected, err := OrderedEntityTypes(selectedEntityTypes)
+	if err != nil {
+		return nil, err
+	}
+	lockTypes := make([]string, 0, len(entityLockKeys))
+	for _, entityType := range selected {
+		lockTypes = append(lockTypes, entityLockDependencies[entityType]...)
+	}
+	return OrderedEntityTypes(lockTypes)
 }
 
 // IsDowngrade reports whether a candidate predates the currently applied dump.

--- a/manifest/execution_test.go
+++ b/manifest/execution_test.go
@@ -30,6 +30,31 @@ func TestOrderedEntityTypesAndLockKeys(t *testing.T) {
 	}
 }
 
+func TestRequiredLockEntityTypes(t *testing.T) {
+	t.Parallel()
+
+	masterLocks, err := RequiredLockEntityTypes([]string{"master"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(masterLocks, []string{"artist", "master"}) {
+		t.Fatalf("RequiredLockEntityTypes(master) = %v", masterLocks)
+	}
+
+	releaseLocks, err := RequiredLockEntityTypes([]string{"label", "release"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := []string{"artist", "label", "master", "release"}
+	if !reflect.DeepEqual(releaseLocks, expected) {
+		t.Fatalf("RequiredLockEntityTypes(label, release) = %v", releaseLocks)
+	}
+
+	if _, err := RequiredLockEntityTypes([]string{"unknown"}); err == nil {
+		t.Fatal("unknown entity type was accepted")
+	}
+}
+
 func TestIsDowngrade(t *testing.T) {
 	t.Parallel()
 

--- a/schema/contracts/import-progress-v1.md
+++ b/schema/contracts/import-progress-v1.md
@@ -54,3 +54,10 @@ an unfinished run can resume.
 The progress contract assumes each committed root entity has converged to the
 exact relation set represented by the dump. Repeating a chunk after a rollback
 must therefore produce the same normalized business state.
+
+Import admission uses exclusive advisory locks for both selected entities and
+their reference dependencies. `master` requires `artist` and `master` locks;
+`release` requires `artist`, `label`, `master`, and `release` locks because it
+reads all three reference sets and updates `master.main_release_id`. Locks are
+always acquired in canonical entity order. This prevents a partial import from
+filtering against a moving reference set or racing a cross-entity write.

--- a/src/main/java/io/dsub/opendiscogs/model/manifest/ImportExecution.java
+++ b/src/main/java/io/dsub/opendiscogs/model/manifest/ImportExecution.java
@@ -19,6 +19,12 @@ public final class ImportExecution {
 
   private static final Map<String, Integer> ENTITY_LOCK_KEYS =
       Map.of("artist", 1, "label", 2, "master", 3, "release", 4);
+  private static final Map<String, List<String>> ENTITY_LOCK_DEPENDENCIES =
+      Map.of(
+          "artist", List.of("artist"),
+          "label", List.of("label"),
+          "master", List.of("artist", "master"),
+          "release", List.of("artist", "label", "master", "release"));
 
   private ImportExecution() {
   }
@@ -51,6 +57,18 @@ public final class ImportExecution {
       unique.add(entityType);
     }
     return unique.stream().sorted().toList();
+  }
+
+  /**
+   * Returns every entity lock needed to update the selected entities without racing a referenced
+   * entity import.
+   */
+  public static List<String> requiredLockEntityTypes(Collection<String> selectedEntityTypes) {
+    return orderedEntityTypes(selectedEntityTypes).stream()
+        .flatMap(entityType -> ENTITY_LOCK_DEPENDENCIES.get(entityType).stream())
+        .distinct()
+        .sorted()
+        .toList();
   }
 
   /**

--- a/src/test/java/io/dsub/opendiscogs/model/manifest/ImportExecutionTest.java
+++ b/src/test/java/io/dsub/opendiscogs/model/manifest/ImportExecutionTest.java
@@ -27,6 +27,19 @@ class ImportExecutionTest {
   }
 
   @Test
+  void expandsSelectedEntitiesToTheirReadAndWriteLockDependencies() {
+    assertEquals(
+        List.of("artist", "master"),
+        ImportExecution.requiredLockEntityTypes(List.of("master")));
+    assertEquals(
+        List.of("artist", "label", "master", "release"),
+        ImportExecution.requiredLockEntityTypes(List.of("label", "release")));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> ImportExecution.requiredLockEntityTypes(List.of("unknown")));
+  }
+
+  @Test
   void comparesCandidateAgainstCheckpointDate() {
     LocalDate checkpoint = LocalDate.of(2026, 7, 1);
 


### PR DESCRIPTION
## Summary
- expand Master admission locks to Artist and Master
- expand Release admission locks to Artist, Label, Master, and Release
- define the same canonical dependency order in Go and Java contracts
- document why partial imports must not observe moving reference sets

## Verification
- `scripts/verify-generated-models.sh`
- `go test ./...`
- `./gradlew test --no-daemon --warning-mode=fail`
- signed commit verified locally