### PR TITLE
perf: add indexed API query paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,17 @@ Per-entity PostgreSQL advisory locks allow disjoint imports to run concurrently
 while rejecting overlapping writers. Older dumps are rejected unless a
 separate, audited downgrade option is explicitly requested.
 
+The schema also owns the bounded read-path indexes used by the Go API. Trigram
+indexes cover artist and label names plus master and release titles; no index is
+created for large profile, contact, or notes fields. Reverse relationship keys
+and release date, country, master, and master-membership filters have dedicated
+indexes. PostgreSQL installations must make the bundled `pg_trgm` extension
+available to the migration owner. After a bulk import, run `ANALYZE` before
+serving traffic so the planner sees the imported data distribution.
+The reproducible synthetic before/after results and their full-dump limitations
+are recorded in
+[`docs/performance/2026-08-11-api-query-indexes.md`](docs/performance/2026-08-11-api-query-indexes.md).
+
 ## Development
 
 The complete local verification requires Docker, Go 1.26, and Temurin 21.
@@ -126,7 +137,7 @@ material are read only from encrypted GitHub Actions secrets.
 
 - [OpenDiscogs Batch](https://github.com/dsub-io/open-discogs-batch)
 - [Go OpenDiscogs Batch](https://github.com/dsub-io/go-open-discogs-batch)
-- [OpenDiscogs API](https://github.com/dsub-io/open-discogs-api)
+- [Go OpenDiscogs API](https://github.com/dsub-io/go-open-discogs-api)
 
 ## License
 

--- a/docs/performance/2026-08-11-api-query-indexes.md
+++ b/docs/performance/2026-08-11-api-query-indexes.md
@@ -1,0 +1,50 @@
+# API query index benchmark (2026-08-11)
+
+## Result
+
+`V007__api_query_indexes.sql` replaced sequential scans on the measured API
+search and reverse-relationship paths with bounded index scans.
+
+| Query | Before p50 / p95 / p99 | After p50 / p95 / p99 | p95 change |
+| --- | ---: | ---: | ---: |
+| Release title substring | 163.887 / 194.535 / 199.306 ms | 0.111 / 0.136 / 0.142 ms | 99.930% lower (1,430.4x) |
+| Releases by artist | 16.717 / 17.309 / 22.187 ms | 0.040 / 0.061 / 0.070 ms | 99.648% lower (283.8x) |
+
+The title query changed from a parallel primary-key scan that rejected 999,997
+rows to a bitmap scan on `ix_release_item_title_trgm`. The artist relationship
+query changed from a parallel sequential scan of 1,000,000 rows to an index-only
+scan on `ix_release_item_artist_artist_release`.
+
+The synthetic database grew from 314,308,287 to 486,389,439 bytes after all
+V007 indexes were added: 164.1 MiB, or 54.7%. This is a deliberate read-latency
+tradeoff and must be remeasured with the full dump before production sizing.
+
+## Conditions
+
+- Apple M2 Pro host, arm64, 12 Docker CPUs, 8 GiB Docker memory
+- PostgreSQL 18.4 Alpine on a 4 GiB tmpfs; no persistent Docker volume
+- 1,000,000 releases, 1,000,000 release-artist relations, 250,000 artists,
+  250,000 masters, and 100,000 labels
+- one client, JIT disabled, five warm-up executions, then 30 measured executions
+- identical data and container for the before and after phases; `ANALYZE` ran
+  before each phase
+
+Run the benchmark from the repository root:
+
+```sh
+scripts/benchmark-api-query-indexes.sh
+```
+
+The script prints all latency samples as p50/p95/p99 summaries and the relevant
+JSON execution plans. Row counts and run counts can be changed with its
+`BENCH_*` environment variables. It owns an exact, labeled container, uses
+tmpfs, and verifies that Docker did not create a volume before removing the
+container on success, failure, or interruption.
+
+## Limits
+
+This is a warm-cache synthetic query benchmark, not a full-dump capacity claim.
+It does not measure concurrent throughput, cold storage I/O, import duration,
+RSS, heap allocation, or production index size. The change is database-only, so
+Go heap and allocation metrics are not applicable to this measurement. Those
+items remain mandatory in the full-dump pre-production rehearsal.

--- a/schema/embed_test.go
+++ b/schema/embed_test.go
@@ -25,6 +25,7 @@ func TestMigrations(t *testing.T) {
 		"V004__allow_reissued_dump_paths.sql",
 		"V005__durable_import_progress.sql",
 		"V006__concurrent_import_progress.sql",
+		"V007__api_query_indexes.sql",
 	}
 	if len(entries) != len(want) {
 		t.Fatalf("migration count = %d, want %d", len(entries), len(want))

--- a/schema/migrations/V007__api_query_indexes.sql
+++ b/schema/migrations/V007__api_query_indexes.sql
@@ -1,0 +1,53 @@
+create extension if not exists pg_trgm;
+
+create index if not exists ix_artist_name_trgm
+    on public.artist using gin (name gin_trgm_ops)
+    where name is not null;
+
+create index if not exists ix_artist_real_name_trgm
+    on public.artist using gin (real_name gin_trgm_ops)
+    where real_name is not null;
+
+create index if not exists ix_label_name_trgm
+    on public.label using gin (name gin_trgm_ops)
+    where name is not null;
+
+create index if not exists ix_master_title_trgm
+    on public.master using gin (title gin_trgm_ops)
+    where title is not null;
+
+create index if not exists ix_release_item_title_trgm
+    on public.release_item using gin (title gin_trgm_ops)
+    where title is not null;
+
+create index if not exists ix_master_year_id
+    on public.master (year, id)
+    where year is not null;
+
+create index if not exists ix_release_item_country_id
+    on public.release_item (lower(country), id)
+    where country is not null;
+
+create index if not exists ix_release_item_release_date_id
+    on public.release_item (release_date, id)
+    where has_valid_year is true;
+
+create index if not exists ix_release_item_is_master_id
+    on public.release_item (is_master, id)
+    where is_master is not null;
+
+create index if not exists ix_release_item_master_id_id
+    on public.release_item (master_id, id)
+    where master_id is not null;
+
+create index if not exists ix_release_item_artist_artist_release
+    on public.release_item_artist (artist_id, release_item_id);
+
+create index if not exists ix_release_item_credited_artist_artist_release
+    on public.release_item_credited_artist (artist_id, release_item_id);
+
+create index if not exists ix_label_release_item_label_release
+    on public.label_release_item (label_id, release_item_id);
+
+create index if not exists ix_label_sub_label_sub_parent
+    on public.label_sub_label (sub_label_id, parent_label_id);

--- a/scripts/benchmark-api-query-indexes.sh
+++ b/scripts/benchmark-api-query-indexes.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repository_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+container_name="open-discogs-model-api-index-benchmark-$$"
+postgres_image="postgres:18.4-alpine"
+release_rows="${BENCH_RELEASE_ROWS:-1000000}"
+artist_rows="${BENCH_ARTIST_ROWS:-250000}"
+label_rows="${BENCH_LABEL_ROWS:-100000}"
+master_rows="${BENCH_MASTER_ROWS:-250000}"
+warmup_runs="${BENCH_WARMUP_RUNS:-5}"
+measured_runs="${BENCH_MEASURED_RUNS:-30}"
+
+require_positive_integer() {
+  local name="$1"
+  local value="$2"
+  if [[ ! "$value" =~ ^[1-9][0-9]*$ ]]; then
+    printf '%s must be a positive integer: %s\n' "$name" "$value" >&2
+    exit 1
+  fi
+}
+
+require_positive_integer BENCH_RELEASE_ROWS "$release_rows"
+require_positive_integer BENCH_ARTIST_ROWS "$artist_rows"
+require_positive_integer BENCH_LABEL_ROWS "$label_rows"
+require_positive_integer BENCH_MASTER_ROWS "$master_rows"
+require_positive_integer BENCH_WARMUP_RUNS "$warmup_runs"
+require_positive_integer BENCH_MEASURED_RUNS "$measured_runs"
+
+cleanup() {
+  case "$container_name" in
+    open-discogs-model-api-index-benchmark-[0-9]*) ;;
+    *)
+      printf 'Refusing to clean unexpected container name: %s\n' "$container_name" >&2
+      return 1
+      ;;
+  esac
+  docker rm --force "$container_name" >/dev/null 2>&1 || true
+  if docker ps -a --filter "name=^/${container_name}$" --format '{{.Names}}' | grep -q .; then
+    printf 'Benchmark container cleanup failed: %s\n' "$container_name" >&2
+    return 1
+  fi
+}
+trap cleanup EXIT INT TERM
+
+docker run \
+  --detach \
+  --name "$container_name" \
+  --label io.dsub.test-owner=open-discogs-model \
+  --tmpfs /var/lib/postgresql:rw,noexec,nosuid,size=4g \
+  --env POSTGRES_DB=modelbench \
+  --env POSTGRES_PASSWORD=modelbench \
+  --env POSTGRES_USER=modelbench \
+  "$postgres_image" >/dev/null
+
+volume_mounts="$(
+  docker inspect \
+    --format '{{range .Mounts}}{{if eq .Type "volume"}}{{println .Name}}{{end}}{{end}}' \
+    "$container_name"
+)"
+if [[ -n "$volume_mounts" ]]; then
+  printf 'Benchmark unexpectedly created Docker volumes: %s\n' "$volume_mounts" >&2
+  exit 1
+fi
+
+for attempt in {1..30}; do
+  if docker exec "$container_name" \
+    psql --username modelbench --dbname modelbench --tuples-only \
+      --command 'select 1' >/dev/null 2>&1; then
+    break
+  fi
+  if [[ "$attempt" == 30 ]]; then
+    printf 'PostgreSQL did not become ready.\n' >&2
+    exit 1
+  fi
+  sleep 1
+done
+
+psql_command() {
+  docker exec "$container_name" \
+    psql --username modelbench --dbname modelbench \
+      --no-psqlrc --no-align --tuples-only --quiet \
+      --set ON_ERROR_STOP=1 --command "$1"
+}
+
+for migration in "$repository_root"/schema/migrations/V00[1-6]__*.sql; do
+  docker exec --interactive "$container_name" \
+    psql --username modelbench --dbname modelbench \
+      --no-psqlrc --quiet --set ON_ERROR_STOP=1 < "$migration"
+done
+
+psql_command "
+  set synchronous_commit = off;
+  insert into artist (id, created_at, last_modified_at, name, real_name)
+  select id, timestamp '2026-08-11', timestamp '2026-08-11',
+         'Artist ' || id, 'Real Artist ' || id
+  from generate_series(1, $artist_rows) as id;
+
+  insert into label (id, created_at, last_modified_at, name)
+  select id, timestamp '2026-08-11', timestamp '2026-08-11', 'Label ' || id
+  from generate_series(1, $label_rows) as id;
+
+  insert into master (id, created_at, last_modified_at, title, year)
+  select id, timestamp '2026-08-11', timestamp '2026-08-11',
+         'Master ' || id, (1950 + id % 76)::smallint
+  from generate_series(1, $master_rows) as id;
+
+  insert into release_item (
+    id, created_at, last_modified_at, country, has_valid_day,
+    has_valid_month, has_valid_year, is_master, master_id,
+    listed_release_date, release_date, title
+  )
+  select id, timestamp '2026-08-11', timestamp '2026-08-11',
+         case id % 4 when 0 then 'US' when 1 then 'JP' when 2 then 'GB' else 'DE' end,
+         true, true, true, id % 2 = 0,
+         1 + id % $master_rows,
+         to_char(make_date(1950 + id % 76, 1 + id % 12, 1 + id % 28), 'YYYY-MM-DD'),
+         make_date(1950 + id % 76, 1 + id % 12, 1 + id % 28),
+         case when id >= $release_rows - 2
+              then 'Rare needle release ' || id
+              else 'Catalog release ' || id end
+  from generate_series(1, $release_rows) as id;
+
+  insert into release_item_artist (
+    id, created_at, last_modified_at, artist_id, release_item_id
+  )
+  select id, timestamp '2026-08-11', timestamp '2026-08-11',
+         1 + id % $artist_rows, id
+  from generate_series(1, $release_rows) as id;
+  analyze;
+"
+
+query_duration() {
+  local query="$1"
+  local plan
+  plan="$(psql_command "set jit = off; explain (analyze, format json) $query")"
+  jq -r '.[0]["Execution Time"]' <<<"$plan"
+}
+
+query_plan() {
+  local query="$1"
+  local plan
+  plan="$(psql_command "set jit = off; explain (analyze, buffers, format json) $query")"
+  jq -c '.[0].Plan' <<<"$plan"
+}
+
+benchmark_query() {
+  local phase="$1"
+  local name="$2"
+  local query="$3"
+  local durations=()
+  local iteration
+
+  for ((iteration = 0; iteration < warmup_runs; iteration++)); do
+    query_duration "$query" >/dev/null
+  done
+  for ((iteration = 0; iteration < measured_runs; iteration++)); do
+    durations+=("$(query_duration "$query")")
+  done
+
+  printf '%s\n' "${durations[@]}" | sort -n | awk \
+    -v phase="$phase" -v name="$name" '
+      { values[NR] = $1 }
+      END {
+        p50 = int((NR - 1) * 0.50) + 1
+        p95 = int((NR - 1) * 0.95) + 1
+        p99 = int((NR - 1) * 0.99) + 1
+        printf "%s\t%s\t%.3f\t%.3f\t%.3f\n",
+          phase, name, values[p50], values[p95], values[p99]
+      }
+    '
+}
+
+deep_offset_query="select id from release_item order by id limit 30 offset $((release_rows - 100))"
+keyset_query="select id from release_item where id > $((release_rows - 100)) order by id limit 31"
+exact_count_query="select count(*) from release_item"
+title_query="select id from release_item where title ilike '%rare needle%' and id > 0 order by id limit 31"
+relationship_query="select release_item_id from release_item_artist where artist_id = $((artist_rows - 1)) and release_item_id > 0 order by release_item_id limit 31"
+
+printf 'phase\tquery\tp50_ms\tp95_ms\tp99_ms\n'
+benchmark_query before deep_offset "$deep_offset_query"
+benchmark_query before exact_count "$exact_count_query"
+benchmark_query before keyset "$keyset_query"
+benchmark_query before title_contains "$title_query"
+benchmark_query before artist_releases "$relationship_query"
+
+printf 'plan_before\ttitle_contains\t%s\n' "$(query_plan "$title_query")"
+printf 'plan_before\tartist_releases\t%s\n' "$(query_plan "$relationship_query")"
+printf 'size_before_bytes\t%s\n' "$(psql_command "select pg_database_size(current_database())")"
+
+docker exec --interactive "$container_name" \
+  psql --username modelbench --dbname modelbench \
+    --no-psqlrc --quiet --set ON_ERROR_STOP=1 \
+    < "$repository_root/schema/migrations/V007__api_query_indexes.sql"
+psql_command 'analyze;'
+
+benchmark_query after keyset "$keyset_query"
+benchmark_query after title_contains "$title_query"
+benchmark_query after artist_releases "$relationship_query"
+printf 'plan_after\ttitle_contains\t%s\n' "$(query_plan "$title_query")"
+printf 'plan_after\tartist_releases\t%s\n' "$(query_plan "$relationship_query")"
+printf 'size_after_bytes\t%s\n' "$(psql_command "select pg_database_size(current_database())")"


### PR DESCRIPTION
## Summary
- add canonical trigram, filtered, and reverse-relation indexes for bounded Go API queries
- document pg_trgm and post-import ANALYZE requirements
- add an exact-container, tmpfs benchmark with automatic cleanup

## Measured result
Synthetic warm-cache PostgreSQL 18.4 benchmark: 1,000,000 releases and release-artist relations, 5 warm-ups, 30 measured runs.

- release title substring p95: 194.535 ms -> 0.136 ms (99.930% lower, 1,430.4x)
- releases by artist p95: 17.309 ms -> 0.061 ms (99.648% lower, 283.8x)
- database size: 314,308,287 -> 486,389,439 bytes (+164.1 MiB, +54.7%)

This is synthetic evidence, not a full-dump capacity claim. Full-dump import duration, index size, cold I/O, and concurrent throughput remain pre-production gates.

## Verification
- `scripts/benchmark-api-query-indexes.sh`
- `scripts/verify-generated-models.sh`
- `go test -race -covermode=atomic ./...`
- `./gradlew clean build --no-daemon --warning-mode=fail`
- `shellcheck scripts/benchmark-api-query-indexes.sh`
- exact benchmark/test containers removed; no benchmark/test volume created