### PR TITLE
fix: preserve release label catalog identities

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ migrations, err := schema.Migrations()
 Files under `schema/migrations` are the only hand-maintained database schema
 source. The Java jOOQ classes and Go structs are generated from a PostgreSQL
 database created from those ordered migrations.
+The Java artifact also contains a generated `migrations/index.txt`; JVM
+consumers use that inventory and the packaged SQL instead of maintaining
+consumer-owned migration copies.
 
 The schema includes the OpenDiscogs catalog tables, immutable dump provenance,
 append-only import-run identity, and bounded progress that becomes historical
@@ -101,6 +104,12 @@ serving traffic so the planner sees the imported data distribution.
 The reproducible synthetic before/after results and their full-dump limitations
 are recorded in
 [`docs/performance/2026-08-11-api-query-indexes.md`](docs/performance/2026-08-11-api-query-indexes.md).
+
+`label_release_item` identifies a Discogs label credit by release, label, and
+catalog number. A release may list the same label more than once with distinct
+catalog-number spelling, and every spelling is preserved. PostgreSQL treats a
+missing catalog number as one identity value so repeated `NULL` entries do not
+create duplicate relations.
 
 ## Development
 

--- a/build.gradle
+++ b/build.gradle
@@ -115,12 +115,14 @@ def migrationFiles = fileTree('schema/migrations') {
     include '*.sql'
 }.files.sort { left, right -> left.name <=> right.name }
 def combinedSchema = layout.buildDirectory.file('generated-schema/postgresql-init.sql')
+def migrationIndex = layout.buildDirectory.file('generated-schema/migrations/index.txt')
 
 tasks.register('prepareSchema') {
     description = 'Combines ordered PostgreSQL migrations for schema code generation.'
     group = 'build setup'
     inputs.files(migrationFiles)
     outputs.file(combinedSchema)
+    outputs.file(migrationIndex)
     doLast {
         def output = combinedSchema.get().asFile
         output.parentFile.mkdirs()
@@ -131,6 +133,14 @@ tasks.register('prepareSchema') {
                 writer.write('\n')
             }
         }
+        def index = migrationIndex.get().asFile
+        index.parentFile.mkdirs()
+        index.withWriter('UTF-8') { writer ->
+            migrationFiles.each { migration ->
+                writer.write(migration.name)
+                writer.write('\n')
+            }
+        }
     }
 }
 
@@ -138,6 +148,10 @@ tasks.named('processResources') {
     dependsOn(tasks.named('prepareSchema'))
     from(combinedSchema) {
         rename { 'postgresql-init.sql' }
+    }
+    from(migrationIndex) {
+        into 'migrations'
+        rename { 'index.txt' }
     }
 }
 
@@ -280,6 +294,17 @@ tasks.register('validateSchemaResources') {
                 .get().asFile.isFile()) {
             throw new GradleException(
                     'Java resources are missing the generated postgresql-init.sql')
+        }
+        def packagedIndex = layout.buildDirectory
+                .file('resources/main/migrations/index.txt').get().asFile
+        if (!packagedIndex.isFile()) {
+            throw new GradleException(
+                    'Java resources are missing the generated migration index')
+        }
+        def indexedMigrations = packagedIndex.readLines('UTF-8')
+        if (indexedMigrations != migrationFiles*.name) {
+            throw new GradleException(
+                    'Java migration index does not match canonical migrations')
         }
         if (!missingMigrations.isEmpty()) {
             throw new GradleException(

--- a/schema/embed_test.go
+++ b/schema/embed_test.go
@@ -26,6 +26,7 @@ func TestMigrations(t *testing.T) {
 		"V005__durable_import_progress.sql",
 		"V006__concurrent_import_progress.sql",
 		"V007__api_query_indexes.sql",
+		"V008__label_release_catalog_identity.sql",
 	}
 	if len(entries) != len(want) {
 		t.Fatalf("migration count = %d, want %d", len(entries), len(want))

--- a/schema/migrations/V008__label_release_catalog_identity.sql
+++ b/schema/migrations/V008__label_release_catalog_identity.sql
@@ -1,0 +1,18 @@
+alter table public.label_release_item
+    drop constraint if exists uq_label_release_item_release_item_id_label_id;
+
+do $migration$
+begin
+    if not exists (
+        select 1
+        from pg_constraint
+        where conname = 'uq_label_release_item_identity'
+          and conrelid = 'public.label_release_item'::regclass
+    ) then
+        alter table public.label_release_item
+            add constraint uq_label_release_item_identity
+                unique nulls not distinct
+                    (release_item_id, label_id, category_notation);
+    end if;
+end
+$migration$;

--- a/scripts/test-migrations.sh
+++ b/scripts/test-migrations.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repository_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+container_name="open-discogs-model-migration-test-$$"
+postgres_image="postgres:18.4-alpine"
+image_was_present=false
+
+cleanup() {
+  case "$container_name" in
+    open-discogs-model-migration-test-[0-9]*) ;;
+    *)
+      printf 'Refusing to clean unexpected container name: %s\n' "$container_name" >&2
+      return 1
+      ;;
+  esac
+  docker rm --force "$container_name" >/dev/null 2>&1 || true
+  if docker ps -a --filter "name=^/${container_name}$" --format '{{.Names}}' | grep -q .; then
+    printf 'Migration test container cleanup failed: %s\n' "$container_name" >&2
+    return 1
+  fi
+  if [[ "$image_was_present" == false ]]; then
+    docker image rm "$postgres_image" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+if docker image inspect "$postgres_image" >/dev/null 2>&1; then
+  image_was_present=true
+fi
+
+docker run \
+  --detach \
+  --name "$container_name" \
+  --label io.dsub.test-owner=open-discogs-model \
+  --tmpfs /var/lib/postgresql:rw,noexec,nosuid,size=512m \
+  --env POSTGRES_DB=migrationtest \
+  --env POSTGRES_PASSWORD=migrationtest \
+  --env POSTGRES_USER=migrationtest \
+  "$postgres_image" >/dev/null
+
+volume_mounts="$(
+  docker inspect \
+    --format '{{range .Mounts}}{{if eq .Type "volume"}}{{println .Name}}{{end}}{{end}}' \
+    "$container_name"
+)"
+if [[ -n "$volume_mounts" ]]; then
+  printf 'Migration test unexpectedly created Docker volumes: %s\n' "$volume_mounts" >&2
+  exit 1
+fi
+
+for attempt in {1..30}; do
+  if docker exec "$container_name" \
+    psql --username migrationtest --dbname migrationtest \
+    --tuples-only --command 'select 1' >/dev/null 2>&1; then
+    break
+  fi
+  if [[ "$attempt" == 30 ]]; then
+    printf 'PostgreSQL did not become ready\n' >&2
+    exit 1
+  fi
+  sleep 1
+done
+
+for version in 001 002 003 004 005 006 007; do
+  migration="$(find "$repository_root/schema/migrations" \
+    -maxdepth 1 -type f -name "V${version}__*.sql" -print -quit)"
+  if [[ -z "$migration" ]]; then
+    printf 'Missing migration V%s\n' "$version" >&2
+    exit 1
+  fi
+  docker exec --interactive "$container_name" \
+    psql --username migrationtest --dbname migrationtest \
+    --set ON_ERROR_STOP=1 < "$migration" >/dev/null
+done
+
+docker exec "$container_name" \
+  psql --username migrationtest --dbname migrationtest \
+  --set ON_ERROR_STOP=1 --command "
+    insert into public.label (id, created_at, last_modified_at)
+    values (5, now(), now());
+    insert into public.release_item (id, created_at, last_modified_at)
+    values (2, now(), now());
+    insert into public.label_release_item (
+      created_at, last_modified_at, category_notation, label_id, release_item_id
+    ) values (now(), now(), 'SK026', 5, 2);
+  " >/dev/null
+
+docker exec --interactive "$container_name" \
+  psql --username migrationtest --dbname migrationtest \
+  --set ON_ERROR_STOP=1 \
+  < "$repository_root/schema/migrations/V008__label_release_catalog_identity.sql" \
+  >/dev/null
+
+docker exec "$container_name" \
+  psql --username migrationtest --dbname migrationtest \
+  --set ON_ERROR_STOP=1 --command "
+    insert into public.label_release_item (
+      created_at, last_modified_at, category_notation, label_id, release_item_id
+    ) values
+      (now(), now(), 'SK 026', 5, 2),
+      (now(), now(), null, 5, 2);
+  " >/dev/null
+
+if docker exec "$container_name" \
+  psql --username migrationtest --dbname migrationtest \
+  --set ON_ERROR_STOP=1 --command "
+    insert into public.label_release_item (
+      created_at, last_modified_at, category_notation, label_id, release_item_id
+    ) values (now(), now(), 'SK026', 5, 2);
+  " >/dev/null 2>&1; then
+  printf 'Duplicate catalog identity was accepted\n' >&2
+  exit 1
+fi
+
+if docker exec "$container_name" \
+  psql --username migrationtest --dbname migrationtest \
+  --set ON_ERROR_STOP=1 --command "
+    insert into public.label_release_item (
+      created_at, last_modified_at, category_notation, label_id, release_item_id
+    ) values (now(), now(), null, 5, 2);
+  " >/dev/null 2>&1; then
+  printf 'Duplicate NULL catalog identity was accepted\n' >&2
+  exit 1
+fi
+
+row_count="$(docker exec "$container_name" \
+  psql --username migrationtest --dbname migrationtest \
+  --no-align --tuples-only \
+  --command 'select count(*) from public.label_release_item')"
+if [[ "$row_count" != 3 ]]; then
+  printf 'Label release migration retained %s rows; expected 3\n' "$row_count" >&2
+  exit 1
+fi

--- a/scripts/verify-generated-models.sh
+++ b/scripts/verify-generated-models.sh
@@ -5,6 +5,7 @@ repository_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 generated_model="$repository_root/model/schema.gen.go"
 before_hash="$(git hash-object "$generated_model")"
 
+"$repository_root/scripts/test-migrations.sh"
 "$repository_root/scripts/generate-go-models.sh"
 after_hash="$(git hash-object "$generated_model")"
 if [[ "$before_hash" != "$after_hash" ]]; then


### PR DESCRIPTION
## Summary
- identify label credits by release, label, and catalog number
- treat missing catalog numbers as one identity with `UNIQUE NULLS NOT DISTINCT`
- publish a generated migration inventory for JVM consumers
- verify V001-V007 upgrade behavior and Docker cleanup

## Evidence
The 2026-08 release dump contains release `2`, label `5` twice with catalog numbers `SK 026` and `SK026`. The previous `(release_item_id, label_id)` key cannot represent both and caused PostgreSQL SQLSTATE 21000 in the first Release chunk.

## Verification
- `scripts/verify-generated-models.sh`
- `go test ./...`
- `./gradlew clean build --no-daemon --warning-mode=fail`
- no test-owned Docker containers or volumes remain