### PR TITLE
feat: add canonical release convergence contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+  merge_group:
 
 permissions:
   contents: read
@@ -43,8 +44,88 @@ jobs:
       - name: Verify generated Go models
         run: scripts/verify-generated-models.sh
 
+      - name: Verify release convergence on supported PostgreSQL versions
+        run: scripts/test-release-convergence-contract.sh
+
       - name: Test Go packages
         run: go test ./...
 
       - name: Build and test Java package
         run: ./gradlew clean build --no-daemon --warning-mode=fail
+
+      - name: Verify packaged schema resource inventory
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          mapfile -t model_jars < <(
+            find build/libs -maxdepth 1 -type f -name '*.jar' \
+              ! -name '*-sources.jar' \
+              ! -name '*-javadoc.jar' \
+              -print
+          )
+          if (( ${#model_jars[@]} != 1 )); then
+            echo "::error::Expected exactly one model JAR, found ${#model_jars[@]}."
+            exit 1
+          fi
+
+          model_jar="${model_jars[0]}"
+          expected_inventory="$(mktemp)"
+          actual_inventory="$(mktemp)"
+          expected_index="$(mktemp)"
+          trap 'rm -f "$expected_inventory" "$actual_inventory" "$expected_index"' EXIT
+
+          find schema/migrations -maxdepth 1 -type f -name 'V*.sql' \
+            -printf '%f\n' | LC_ALL=C sort > "$expected_index"
+          if [[ ! -s "$expected_index" ]]; then
+            echo '::error::Canonical migration inventory is empty.'
+            exit 1
+          fi
+
+          {
+            echo postgresql-init.sql
+            echo migrations/index.txt
+            echo io/dsub/opendiscogs/schema/migrations/index.txt
+            while IFS= read -r migration_name; do
+              echo "migrations/$migration_name"
+              echo "io/dsub/opendiscogs/schema/migrations/$migration_name"
+            done < "$expected_index"
+            find schema/contracts -type f -printf '%P\n' | LC_ALL=C sort |
+              while IFS= read -r contract_name; do
+                echo "contracts/$contract_name"
+                echo "io/dsub/opendiscogs/schema/contracts/$contract_name"
+              done
+          } | LC_ALL=C sort > "$expected_inventory"
+
+          jar --list --file "$model_jar" |
+            awk '
+              $0 == "postgresql-init.sql" ||
+              $0 == "migrations/index.txt" ||
+              $0 == "io/dsub/opendiscogs/schema/migrations/index.txt" ||
+              $0 ~ /^migrations\/V[0-9][0-9][0-9]__[a-z0-9_]+\.sql$/ ||
+              $0 ~ /^io\/dsub\/opendiscogs\/schema\/migrations\/V[0-9][0-9][0-9]__[a-z0-9_]+\.sql$/ ||
+              $0 ~ /^contracts\/[^/].*$/ ||
+              $0 ~ /^io\/dsub\/opendiscogs\/schema\/contracts\/[^/].*$/
+            ' | LC_ALL=C sort > "$actual_inventory"
+          diff --unified "$expected_inventory" "$actual_inventory"
+
+          unzip -p "$model_jar" migrations/index.txt | cmp - "$expected_index"
+          unzip -p "$model_jar" \
+            io/dsub/opendiscogs/schema/migrations/index.txt |
+            cmp - "$expected_index"
+
+          while IFS= read -r migration_name; do
+            unzip -p "$model_jar" "migrations/$migration_name" |
+              cmp - "schema/migrations/$migration_name"
+            unzip -p "$model_jar" \
+              "io/dsub/opendiscogs/schema/migrations/$migration_name" |
+              cmp - "schema/migrations/$migration_name"
+          done < "$expected_index"
+
+          while IFS= read -r contract_path; do
+            unzip -p "$model_jar" "contracts/$contract_path" |
+              cmp - "schema/contracts/$contract_path"
+            unzip -p "$model_jar" \
+              "io/dsub/opendiscogs/schema/contracts/$contract_path" |
+              cmp - "schema/contracts/$contract_path"
+          done < <(find schema/contracts -type f -printf '%P\n' | LC_ALL=C sort)

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -7,6 +7,7 @@ on:
       - reopened
       - synchronize
       - edited
+  merge_group:
   push:
     branches:
       - main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -194,6 +194,9 @@ jobs:
           scripts/verify-generated-models.sh
           go test ./...
 
+      - name: Verify release convergence on supported PostgreSQL versions
+        run: scripts/test-release-convergence-contract.sh
+
       - name: Build Maven Central artifacts
         shell: bash
         env:
@@ -204,6 +207,83 @@ jobs:
             -PreleaseVersion="$RELEASE_VERSION" \
             --no-daemon \
             --warning-mode=fail
+
+      - name: Verify packaged schema resource inventory
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          mapfile -t model_jars < <(
+            find build/libs -maxdepth 1 -type f -name '*.jar' \
+              ! -name '*-sources.jar' \
+              ! -name '*-javadoc.jar' \
+              -print
+          )
+          if (( ${#model_jars[@]} != 1 )); then
+            echo "::error::Expected exactly one model JAR, found ${#model_jars[@]}."
+            exit 1
+          fi
+
+          model_jar="${model_jars[0]}"
+          expected_inventory="$(mktemp)"
+          actual_inventory="$(mktemp)"
+          expected_index="$(mktemp)"
+          trap 'rm -f "$expected_inventory" "$actual_inventory" "$expected_index"' EXIT
+
+          find schema/migrations -maxdepth 1 -type f -name 'V*.sql' \
+            -printf '%f\n' | LC_ALL=C sort > "$expected_index"
+          if [[ ! -s "$expected_index" ]]; then
+            echo '::error::Canonical migration inventory is empty.'
+            exit 1
+          fi
+
+          {
+            echo postgresql-init.sql
+            echo migrations/index.txt
+            echo io/dsub/opendiscogs/schema/migrations/index.txt
+            while IFS= read -r migration_name; do
+              echo "migrations/$migration_name"
+              echo "io/dsub/opendiscogs/schema/migrations/$migration_name"
+            done < "$expected_index"
+            find schema/contracts -type f -printf '%P\n' | LC_ALL=C sort |
+              while IFS= read -r contract_name; do
+                echo "contracts/$contract_name"
+                echo "io/dsub/opendiscogs/schema/contracts/$contract_name"
+              done
+          } | LC_ALL=C sort > "$expected_inventory"
+
+          jar --list --file "$model_jar" |
+            awk '
+              $0 == "postgresql-init.sql" ||
+              $0 == "migrations/index.txt" ||
+              $0 == "io/dsub/opendiscogs/schema/migrations/index.txt" ||
+              $0 ~ /^migrations\/V[0-9][0-9][0-9]__[a-z0-9_]+\.sql$/ ||
+              $0 ~ /^io\/dsub\/opendiscogs\/schema\/migrations\/V[0-9][0-9][0-9]__[a-z0-9_]+\.sql$/ ||
+              $0 ~ /^contracts\/[^/].*$/ ||
+              $0 ~ /^io\/dsub\/opendiscogs\/schema\/contracts\/[^/].*$/
+            ' | LC_ALL=C sort > "$actual_inventory"
+          diff --unified "$expected_inventory" "$actual_inventory"
+
+          unzip -p "$model_jar" migrations/index.txt | cmp - "$expected_index"
+          unzip -p "$model_jar" \
+            io/dsub/opendiscogs/schema/migrations/index.txt |
+            cmp - "$expected_index"
+
+          while IFS= read -r migration_name; do
+            unzip -p "$model_jar" "migrations/$migration_name" |
+              cmp - "schema/migrations/$migration_name"
+            unzip -p "$model_jar" \
+              "io/dsub/opendiscogs/schema/migrations/$migration_name" |
+              cmp - "schema/migrations/$migration_name"
+          done < "$expected_index"
+
+          while IFS= read -r contract_path; do
+            unzip -p "$model_jar" "contracts/$contract_path" |
+              cmp - "schema/contracts/$contract_path"
+            unzip -p "$model_jar" \
+              "io/dsub/opendiscogs/schema/contracts/$contract_path" |
+              cmp - "schema/contracts/$contract_path"
+          done < <(find schema/contracts -type f -printf '%P\n' | LC_ALL=C sort)
 
       - name: Sign and package Maven Central bundle
         id: bundle

--- a/README.md
+++ b/README.md
@@ -61,9 +61,32 @@ migrations, err := schema.Migrations()
 Files under `schema/migrations` are the only hand-maintained database schema
 source. The Java jOOQ classes and Go structs are generated from a PostgreSQL
 database created from those ordered migrations.
-The Java artifact also contains a generated `migrations/index.txt`; JVM
-consumers use that inventory and the packaged SQL instead of maintaining
-consumer-owned migration copies.
+The Java artifact contains a generated migration inventory and byte-identical
+SQL under `io/dsub/opendiscogs/schema/migrations`. JVM consumers use that
+namespaced inventory instead of maintaining consumer-owned migration copies.
+The legacy `migrations` resource path remains packaged only for compatibility
+with released Liquibase consumers.
+
+Canonical migrations require PostgreSQL 15 or newer. Consumers calculate
+checksums from the original packaged SQL bytes and only then scope canonical
+`public` references to an operator-selected schema.
+
+### Legacy Liquibase compatibility
+
+The model owns a strict
+[`legacy-liquibase-v1`](schema/contracts/legacy-liquibase-v1.md) contract for
+adopting Java Batch `1.0.0` through `1.2.1` Liquibase history into the shared
+canonical migration ledger. The Go `schema.LegacyLiquibaseCompatibility` API
+validates its typed manifest against the packaged V001-V007 SQL inventory and
+contract resources.
+
+Public `EXECUTED` history requires the exact released Liquibase checksum.
+Custom-schema checksums depend on the configured schema name, and permitted
+`MARK_RAN` rows do not prove that SQL executed. Those cases require the
+model-owned PostgreSQL catalog fingerprint for the complete V004, V006, or V007
+historical prefix before any canonical ledger rows are adopted. Unknown
+PostgreSQL majors, partial histories, duplicate identities, and fingerprint
+mismatches fail closed.
 
 The schema includes the OpenDiscogs catalog tables, immutable dump provenance,
 append-only import-run identity, and bounded progress that becomes historical
@@ -74,6 +97,11 @@ The [`import-progress-v1`](schema/contracts/import-progress-v1.md) contract
 keeps one summary row per selected entity and a resumable chunk ledger. The
 ledger supports parallel commits without treating gaps as completed work and
 may be pruned once a successful run no longer needs it.
+Each `discogs_import_run_dump` row also records the entity-specific import
+contract revision. Successful checkpoints are reusable across Java and Go only
+at the current entity revision; interrupted runs additionally require the same
+processor name and version. V009 preserves existing rows at revision `1` and
+sets the current contract to `artist=1`, `label=1`, `master=1`, and `release=2`.
 Application-specific Spring Batch metadata and query logic do not belong to
 this module.
 
@@ -110,6 +138,13 @@ catalog number. A release may list the same label more than once with distinct
 catalog-number spelling, and every spelling is preserved. PostgreSQL treats a
 missing catalog number as one identity value so repeated `NULL` entries do not
 create duplicate relations.
+
+A master can name only a release that belongs to that same master as its main
+release, and one release cannot be the main release of multiple masters. V009
+validates existing data before adding these constraints; it does not silently
+repair conflicts. Creating the supporting unique indexes on a populated
+production database requires a measured maintenance window and sufficient
+temporary disk capacity.
 
 ## Development
 

--- a/build.gradle
+++ b/build.gradle
@@ -116,6 +116,11 @@ def migrationFiles = fileTree('schema/migrations') {
 }.files.sort { left, right -> left.name <=> right.name }
 def combinedSchema = layout.buildDirectory.file('generated-schema/postgresql-init.sql')
 def migrationIndex = layout.buildDirectory.file('generated-schema/migrations/index.txt')
+def namespacedMigrationDirectory = 'io/dsub/opendiscogs/schema/migrations'
+def namespacedContractDirectory = 'io/dsub/opendiscogs/schema/contracts'
+def schemaContractFiles = fileTree('schema/contracts') {
+    include '**/*'
+}
 
 tasks.register('prepareSchema') {
     description = 'Combines ordered PostgreSQL migrations for schema code generation.'
@@ -152,6 +157,16 @@ tasks.named('processResources') {
     from(migrationIndex) {
         into 'migrations'
         rename { 'index.txt' }
+    }
+    from(migrationFiles) {
+        into namespacedMigrationDirectory
+    }
+    from(migrationIndex) {
+        into namespacedMigrationDirectory
+        rename { 'index.txt' }
+    }
+    from(schemaContractFiles) {
+        into namespacedContractDirectory
     }
 }
 
@@ -281,35 +296,76 @@ check.dependsOn(tasks.named('validateGeneratedSchema'))
 check.dependsOn(tasks.named('validatePublicationPom'))
 
 tasks.register('validateSchemaResources') {
-    description = 'Checks the Java artifact ships every canonical schema migration.'
+    description = 'Checks generic and namespaced Java migration resources match canonical SQL.'
     group = 'verification'
     dependsOn(tasks.named('processResources'))
     inputs.files(migrationFiles)
+    inputs.files(schemaContractFiles)
     doLast {
-        def missingMigrations = migrationFiles.findAll {
-            !layout.buildDirectory.file("resources/main/migrations/${it.name}")
-                    .get().asFile.isFile()
+        def migrationNames = migrationFiles*.name
+        if (migrationNames.isEmpty()) {
+            throw new GradleException('Canonical migration inventory must not be empty')
+        }
+        def invalidNames = migrationNames.findAll {
+            !(it ==~ /V\d{3}__[a-z0-9_]+\.sql/)
+        }
+        if (!invalidNames.isEmpty()) {
+            throw new GradleException(
+                    "Canonical migration names are invalid:\n - "
+                            + invalidNames.join('\n - '))
+        }
+        def versions = migrationNames.collect {
+            Integer.parseInt(it.substring(1, 4))
+        }
+        def expectedVersions = (1..migrationNames.size()).toList()
+        if (versions != expectedVersions) {
+            throw new GradleException(
+                    "Canonical migration versions must be contiguous: " + versions)
         }
         if (!layout.buildDirectory.file('resources/main/postgresql-init.sql')
                 .get().asFile.isFile()) {
             throw new GradleException(
                     'Java resources are missing the generated postgresql-init.sql')
         }
-        def packagedIndex = layout.buildDirectory
-                .file('resources/main/migrations/index.txt').get().asFile
-        if (!packagedIndex.isFile()) {
-            throw new GradleException(
-                    'Java resources are missing the generated migration index')
+        ['migrations', namespacedMigrationDirectory].each { resourceDirectory ->
+            def packagedIndex = layout.buildDirectory
+                    .file("resources/main/${resourceDirectory}/index.txt").get().asFile
+            if (!packagedIndex.isFile()) {
+                throw new GradleException(
+                        "Java resources are missing ${resourceDirectory}/index.txt")
+            }
+            def indexedMigrations = packagedIndex.readLines('UTF-8')
+            if (indexedMigrations != migrationNames
+                    || indexedMigrations.toSet().size() != indexedMigrations.size()) {
+                throw new GradleException(
+                        "Java migration index is incomplete or duplicated: ${resourceDirectory}")
+            }
+            migrationFiles.each { sourceMigration ->
+                def packagedMigration = layout.buildDirectory
+                        .file("resources/main/${resourceDirectory}/${sourceMigration.name}")
+                        .get().asFile
+                if (!packagedMigration.isFile()
+                        || !java.util.Arrays.equals(
+                                sourceMigration.bytes, packagedMigration.bytes)) {
+                    throw new GradleException(
+                            "Java migration resource differs from canonical SQL: "
+                                    + "${resourceDirectory}/${sourceMigration.name}")
+                }
+            }
         }
-        def indexedMigrations = packagedIndex.readLines('UTF-8')
-        if (indexedMigrations != migrationFiles*.name) {
-            throw new GradleException(
-                    'Java migration index does not match canonical migrations')
-        }
-        if (!missingMigrations.isEmpty()) {
-            throw new GradleException(
-                    "Java resources are missing schema migrations:\n - "
-                            + missingMigrations*.name.join('\n - '))
+        schemaContractFiles.each { sourceContract ->
+            def relativePath = file('schema/contracts').toPath()
+                    .relativize(sourceContract.toPath()).toString()
+            def packagedContract = layout.buildDirectory
+                    .file("resources/main/${namespacedContractDirectory}/${relativePath}")
+                    .get().asFile
+            if (!packagedContract.isFile()
+                    || !java.util.Arrays.equals(
+                            sourceContract.bytes, packagedContract.bytes)) {
+                throw new GradleException(
+                        'Namespaced Java contract resource differs from canonical source: '
+                                + relativePath)
+            }
         }
     }
 }

--- a/manifest/execution.go
+++ b/manifest/execution.go
@@ -17,6 +17,13 @@ var entityLockKeys = map[string]int32{
 	"release": 4,
 }
 
+var entityImportContractRevisions = map[string]int32{
+	"artist":  1,
+	"label":   1,
+	"master":  1,
+	"release": 2,
+}
+
 var entityLockDependencies = map[string][]string{
 	"artist":  {"artist"},
 	"label":   {"label"},
@@ -31,6 +38,17 @@ func EntityLockKey(entityType string) (int32, error) {
 		return 0, fmt.Errorf("unknown entity type %q", entityType)
 	}
 	return key, nil
+}
+
+// ImportContractRevision returns the current stored-data semantics revision for an entity.
+// Successful checkpoints are compatible across processors only at this revision; interrupted
+// runs still require an exact processor name and version match.
+func ImportContractRevision(entityType string) (int32, error) {
+	revision, found := entityImportContractRevisions[strings.ToLower(entityType)]
+	if !found {
+		return 0, fmt.Errorf("unknown entity type %q", entityType)
+	}
+	return revision, nil
 }
 
 // OrderedEntityTypes validates, de-duplicates, and sorts entity types before lock acquisition.

--- a/manifest/execution_test.go
+++ b/manifest/execution_test.go
@@ -30,6 +30,31 @@ func TestOrderedEntityTypesAndLockKeys(t *testing.T) {
 	}
 }
 
+func TestImportContractRevision(t *testing.T) {
+	t.Parallel()
+
+	want := map[string]int32{"artist": 1, "label": 1, "master": 1, "release": 2}
+	for entityType, expected := range want {
+		revision, err := ImportContractRevision(entityType)
+		if err != nil {
+			t.Fatalf("ImportContractRevision(%q) error = %v", entityType, err)
+		}
+		if revision != expected {
+			t.Errorf("ImportContractRevision(%q) = %d, want %d", entityType, revision, expected)
+		}
+		if revision <= 0 {
+			t.Errorf("ImportContractRevision(%q) = %d, want positive", entityType, revision)
+		}
+	}
+	revision, err := ImportContractRevision("RELEASE")
+	if err != nil || revision != want["release"] {
+		t.Fatalf("ImportContractRevision uppercase = %d, %v", revision, err)
+	}
+	if _, err := ImportContractRevision("unknown"); err == nil {
+		t.Fatal("ImportContractRevision(unknown) error = nil")
+	}
+}
+
 func TestRequiredLockEntityTypes(t *testing.T) {
 	t.Parallel()
 

--- a/model/schema.gen.go
+++ b/model/schema.gen.go
@@ -185,15 +185,16 @@ func (DiscogsImportRunChunk) TableName() string { return "discogs_import_run_chu
 
 // DiscogsImportRunDump represents a row in discogs_import_run_dump.
 type DiscogsImportRunDump struct {
-	ImportRunID    int64      `db:"import_run_id" json:"import_run_id" gorm:"column:import_run_id;primaryKey"`
-	EntityType     string     `db:"entity_type" json:"entity_type" gorm:"column:entity_type;primaryKey"`
-	DumpID         int64      `db:"dump_id" json:"dump_id" gorm:"column:dump_id"`
-	ProcessedItems int64      `db:"processed_items" json:"processed_items" gorm:"column:processed_items"`
-	LastProgressAt *time.Time `db:"last_progress_at" json:"last_progress_at" gorm:"column:last_progress_at"`
-	CompletedAt    *time.Time `db:"completed_at" json:"completed_at" gorm:"column:completed_at"`
-	ChunkSize      *int64     `db:"chunk_size" json:"chunk_size" gorm:"column:chunk_size"`
-	TotalItems     *int64     `db:"total_items" json:"total_items" gorm:"column:total_items"`
-	TotalChunks    *int64     `db:"total_chunks" json:"total_chunks" gorm:"column:total_chunks"`
+	ImportRunID            int64      `db:"import_run_id" json:"import_run_id" gorm:"column:import_run_id;primaryKey"`
+	EntityType             string     `db:"entity_type" json:"entity_type" gorm:"column:entity_type;primaryKey"`
+	DumpID                 int64      `db:"dump_id" json:"dump_id" gorm:"column:dump_id"`
+	ProcessedItems         int64      `db:"processed_items" json:"processed_items" gorm:"column:processed_items"`
+	LastProgressAt         *time.Time `db:"last_progress_at" json:"last_progress_at" gorm:"column:last_progress_at"`
+	CompletedAt            *time.Time `db:"completed_at" json:"completed_at" gorm:"column:completed_at"`
+	ChunkSize              *int64     `db:"chunk_size" json:"chunk_size" gorm:"column:chunk_size"`
+	TotalItems             *int64     `db:"total_items" json:"total_items" gorm:"column:total_items"`
+	TotalChunks            *int64     `db:"total_chunks" json:"total_chunks" gorm:"column:total_chunks"`
+	ImportContractRevision int32      `db:"import_contract_revision" json:"import_contract_revision" gorm:"column:import_contract_revision"`
 }
 
 // TableName returns the PostgreSQL table represented by DiscogsImportRunDump.

--- a/schema/contracts/legacy-liquibase-v1.json
+++ b/schema/contracts/legacy-liquibase-v1.json
@@ -1,0 +1,397 @@
+{
+  "formatVersion": 1,
+  "contract": "open-discogs-legacy-liquibase/v1",
+  "schemaDefinition": {
+    "name": "legacy-liquibase-v1.schema.json",
+    "sha256": "33df80a1c3832dc71d8c5c43eabbd17f90ec12f949a8e83dc130fe7e342b5bf6"
+  },
+  "liquibaseVersion": "5.0.3",
+  "liquibaseChecksumVersion": 9,
+  "schemaContracts": [
+    {
+      "prefix": "V004",
+      "migrationVersions": [
+        "V001",
+        "V002",
+        "V003",
+        "V004"
+      ],
+      "verifier": {
+        "name": "legacy-schema-fingerprint-v1.sql",
+        "sha256": "a33713235ad9832b378b25761b7bbc3efdd1dd4436c9ad9d87afb18e40960c65"
+      },
+      "expectedFingerprints": [
+        {
+          "postgresMajor": 15,
+          "sha256": "d5f12dac9987e1dacc08da3e4344ea69ea94a33ca7710a199dff746eabbbea13"
+        },
+        {
+          "postgresMajor": 16,
+          "sha256": "d5f12dac9987e1dacc08da3e4344ea69ea94a33ca7710a199dff746eabbbea13"
+        },
+        {
+          "postgresMajor": 17,
+          "sha256": "d5f12dac9987e1dacc08da3e4344ea69ea94a33ca7710a199dff746eabbbea13"
+        },
+        {
+          "postgresMajor": 18,
+          "sha256": "70b2067ac2e903f418d8328b1452d516329c25dc3d5cf22e16793c53cc480b85"
+        }
+      ]
+    },
+    {
+      "prefix": "V006",
+      "migrationVersions": [
+        "V001",
+        "V002",
+        "V003",
+        "V004",
+        "V005",
+        "V006"
+      ],
+      "verifier": {
+        "name": "legacy-schema-fingerprint-v1.sql",
+        "sha256": "a33713235ad9832b378b25761b7bbc3efdd1dd4436c9ad9d87afb18e40960c65"
+      },
+      "expectedFingerprints": [
+        {
+          "postgresMajor": 15,
+          "sha256": "f938441af564ca35be8a250a6bbef067dce516833c678170e41f6716e882abef"
+        },
+        {
+          "postgresMajor": 16,
+          "sha256": "f938441af564ca35be8a250a6bbef067dce516833c678170e41f6716e882abef"
+        },
+        {
+          "postgresMajor": 17,
+          "sha256": "f938441af564ca35be8a250a6bbef067dce516833c678170e41f6716e882abef"
+        },
+        {
+          "postgresMajor": 18,
+          "sha256": "ee13b6c63977044ca11eeae68473cc6f224d28069cf34357b18e824ba0cf8b38"
+        }
+      ]
+    },
+    {
+      "prefix": "V007",
+      "migrationVersions": [
+        "V001",
+        "V002",
+        "V003",
+        "V004",
+        "V005",
+        "V006",
+        "V007"
+      ],
+      "verifier": {
+        "name": "legacy-schema-fingerprint-v1.sql",
+        "sha256": "a33713235ad9832b378b25761b7bbc3efdd1dd4436c9ad9d87afb18e40960c65"
+      },
+      "expectedFingerprints": [
+        {
+          "postgresMajor": 15,
+          "sha256": "caf5eb22e8d534ee6b137bb411e40c90c5059f0b9031f6bd523a737b4270deca"
+        },
+        {
+          "postgresMajor": 16,
+          "sha256": "caf5eb22e8d534ee6b137bb411e40c90c5059f0b9031f6bd523a737b4270deca"
+        },
+        {
+          "postgresMajor": 17,
+          "sha256": "caf5eb22e8d534ee6b137bb411e40c90c5059f0b9031f6bd523a737b4270deca"
+        },
+        {
+          "postgresMajor": 18,
+          "sha256": "833cdf351ec53874c1cc244578e3aac2e0b87bcb68f8228b0d4286977d190d13"
+        }
+      ]
+    }
+  ],
+  "migrations": [
+    {
+      "version": "V001",
+      "canonicalFilename": "V001__initial_schema.sql",
+      "canonicalSha256": "c84f92887d4d22dfbdb34645d1e50abb9ea28fe663531accb7eb764756fb23f0",
+      "legacyChangeSets": [
+        {
+          "schemaMode": "PUBLIC",
+          "id": "open-discogs-model-v001",
+          "author": "state303",
+          "filename": "db/changelog/db.changelog-master.xml",
+          "checksumPolicy": "EXACT",
+          "checksum": "9:21b43c01c07539940ef584360151932e",
+          "executionPolicies": [
+            {
+              "executionType": "EXECUTED",
+              "adoptionProof": "EXACT_CHECKSUM"
+            },
+            {
+              "executionType": "MARK_RAN",
+              "adoptionProof": "SCHEMA_CONTRACT"
+            }
+          ]
+        },
+        {
+          "schemaMode": "CUSTOM",
+          "id": "open-discogs-model-v001",
+          "author": "state303",
+          "filename": "db/changelog/db.changelog-custom-schema.xml",
+          "checksumPolicy": "SCHEMA_PARAMETERIZED",
+          "schemaParameter": "databaseSchema",
+          "executionPolicies": [
+            {
+              "executionType": "EXECUTED",
+              "adoptionProof": "SCHEMA_CONTRACT"
+            },
+            {
+              "executionType": "MARK_RAN",
+              "adoptionProof": "SCHEMA_CONTRACT"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "version": "V002",
+      "canonicalFilename": "V002__discogs_dump_catalog.sql",
+      "canonicalSha256": "8c189a02f22275868432f87d2858551894b264ff2e3aef0f5757a6ad7fb2ad44",
+      "legacyChangeSets": [
+        {
+          "schemaMode": "PUBLIC",
+          "id": "open-discogs-model-v002",
+          "author": "state303",
+          "filename": "db/changelog/db.changelog-master.xml",
+          "checksumPolicy": "EXACT",
+          "checksum": "9:1fe2b5ca5132d441129f7734864389bb",
+          "executionPolicies": [
+            {
+              "executionType": "EXECUTED",
+              "adoptionProof": "EXACT_CHECKSUM"
+            },
+            {
+              "executionType": "MARK_RAN",
+              "adoptionProof": "SCHEMA_CONTRACT"
+            }
+          ]
+        },
+        {
+          "schemaMode": "CUSTOM",
+          "id": "open-discogs-model-v002",
+          "author": "state303",
+          "filename": "db/changelog/db.changelog-custom-schema.xml",
+          "checksumPolicy": "SCHEMA_PARAMETERIZED",
+          "schemaParameter": "databaseSchema",
+          "executionPolicies": [
+            {
+              "executionType": "EXECUTED",
+              "adoptionProof": "SCHEMA_CONTRACT"
+            },
+            {
+              "executionType": "MARK_RAN",
+              "adoptionProof": "SCHEMA_CONTRACT"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "version": "V003",
+      "canonicalFilename": "V003__discogs_import_history.sql",
+      "canonicalSha256": "8d7befa1ad26771a863413dd341be2eeff1eaa1ae9a4de4088253a18a5fe4620",
+      "legacyChangeSets": [
+        {
+          "schemaMode": "PUBLIC",
+          "id": "open-discogs-model-v003",
+          "author": "state303",
+          "filename": "db/changelog/db.changelog-master.xml",
+          "checksumPolicy": "EXACT",
+          "checksum": "9:b9d40e8e8cb0f59b0d15e764f7af4070",
+          "executionPolicies": [
+            {
+              "executionType": "EXECUTED",
+              "adoptionProof": "EXACT_CHECKSUM"
+            },
+            {
+              "executionType": "MARK_RAN",
+              "adoptionProof": "SCHEMA_CONTRACT"
+            }
+          ]
+        },
+        {
+          "schemaMode": "CUSTOM",
+          "id": "open-discogs-model-v003",
+          "author": "state303",
+          "filename": "db/changelog/db.changelog-custom-schema.xml",
+          "checksumPolicy": "SCHEMA_PARAMETERIZED",
+          "schemaParameter": "databaseSchema",
+          "executionPolicies": [
+            {
+              "executionType": "EXECUTED",
+              "adoptionProof": "SCHEMA_CONTRACT"
+            },
+            {
+              "executionType": "MARK_RAN",
+              "adoptionProof": "SCHEMA_CONTRACT"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "version": "V004",
+      "canonicalFilename": "V004__allow_reissued_dump_paths.sql",
+      "canonicalSha256": "b73b183c7ef8495d711abbd72aa98a130f0fcb98afbe8e5e82e052278100ff0e",
+      "legacyChangeSets": [
+        {
+          "schemaMode": "PUBLIC",
+          "id": "open-discogs-model-v004",
+          "author": "state303",
+          "filename": "db/changelog/db.changelog-master.xml",
+          "checksumPolicy": "EXACT",
+          "checksum": "9:c500950a7ae85ad47ea9ba14c857df39",
+          "executionPolicies": [
+            {
+              "executionType": "EXECUTED",
+              "adoptionProof": "EXACT_CHECKSUM"
+            }
+          ]
+        },
+        {
+          "schemaMode": "CUSTOM",
+          "id": "open-discogs-model-v004",
+          "author": "state303",
+          "filename": "db/changelog/db.changelog-custom-schema.xml",
+          "checksumPolicy": "SCHEMA_PARAMETERIZED",
+          "schemaParameter": "databaseSchema",
+          "executionPolicies": [
+            {
+              "executionType": "EXECUTED",
+              "adoptionProof": "SCHEMA_CONTRACT"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "version": "V005",
+      "canonicalFilename": "V005__durable_import_progress.sql",
+      "canonicalSha256": "a9784e437a0ebaf6c9b5bd93388e5a8f53ecedc53f97c714154265a78617f5cb",
+      "legacyChangeSets": [
+        {
+          "schemaMode": "PUBLIC",
+          "id": "open-discogs-model-v005",
+          "author": "state303",
+          "filename": "db/changelog/db.changelog-master.xml",
+          "checksumPolicy": "EXACT",
+          "checksum": "9:363a63d36fadeea4d0dc435601398341",
+          "executionPolicies": [
+            {
+              "executionType": "EXECUTED",
+              "adoptionProof": "EXACT_CHECKSUM"
+            },
+            {
+              "executionType": "MARK_RAN",
+              "adoptionProof": "SCHEMA_CONTRACT"
+            }
+          ]
+        },
+        {
+          "schemaMode": "CUSTOM",
+          "id": "open-discogs-model-v005",
+          "author": "state303",
+          "filename": "db/changelog/db.changelog-custom-schema.xml",
+          "checksumPolicy": "SCHEMA_PARAMETERIZED",
+          "schemaParameter": "databaseSchema",
+          "executionPolicies": [
+            {
+              "executionType": "EXECUTED",
+              "adoptionProof": "SCHEMA_CONTRACT"
+            },
+            {
+              "executionType": "MARK_RAN",
+              "adoptionProof": "SCHEMA_CONTRACT"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "version": "V006",
+      "canonicalFilename": "V006__concurrent_import_progress.sql",
+      "canonicalSha256": "d1568b6a934bcdc50cfab590c18fc18fedda661c01aefac24cd7d7c149561f45",
+      "legacyChangeSets": [
+        {
+          "schemaMode": "PUBLIC",
+          "id": "open-discogs-model-v006",
+          "author": "state303",
+          "filename": "db/changelog/db.changelog-master.xml",
+          "checksumPolicy": "EXACT",
+          "checksum": "9:c89cf57ca3b13c733e9db92d2c2935a8",
+          "executionPolicies": [
+            {
+              "executionType": "EXECUTED",
+              "adoptionProof": "EXACT_CHECKSUM"
+            },
+            {
+              "executionType": "MARK_RAN",
+              "adoptionProof": "SCHEMA_CONTRACT"
+            }
+          ]
+        },
+        {
+          "schemaMode": "CUSTOM",
+          "id": "open-discogs-model-v006",
+          "author": "state303",
+          "filename": "db/changelog/db.changelog-custom-schema.xml",
+          "checksumPolicy": "SCHEMA_PARAMETERIZED",
+          "schemaParameter": "databaseSchema",
+          "executionPolicies": [
+            {
+              "executionType": "EXECUTED",
+              "adoptionProof": "SCHEMA_CONTRACT"
+            },
+            {
+              "executionType": "MARK_RAN",
+              "adoptionProof": "SCHEMA_CONTRACT"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "version": "V007",
+      "canonicalFilename": "V007__api_query_indexes.sql",
+      "canonicalSha256": "92bf45c9b01da04026ab2a0850136cc953262bda99b41f9a64324d3a4a201fc7",
+      "legacyChangeSets": [
+        {
+          "schemaMode": "PUBLIC",
+          "id": "open-discogs-model-v007",
+          "author": "state303",
+          "filename": "db/changelog/db.changelog-master.xml",
+          "checksumPolicy": "EXACT",
+          "checksum": "9:f60af7da668a40343f647837995b87ec",
+          "executionPolicies": [
+            {
+              "executionType": "EXECUTED",
+              "adoptionProof": "EXACT_CHECKSUM"
+            }
+          ]
+        },
+        {
+          "schemaMode": "CUSTOM",
+          "id": "open-discogs-model-v007",
+          "author": "state303",
+          "filename": "db/changelog/db.changelog-custom-schema.xml",
+          "checksumPolicy": "SCHEMA_PARAMETERIZED",
+          "schemaParameter": "databaseSchema",
+          "executionPolicies": [
+            {
+              "executionType": "EXECUTED",
+              "adoptionProof": "SCHEMA_CONTRACT"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/schema/contracts/legacy-liquibase-v1.md
+++ b/schema/contracts/legacy-liquibase-v1.md
@@ -1,0 +1,67 @@
+# Legacy Liquibase compatibility v1
+
+This contract permits the shared canonical migration ledger to adopt schema
+history written by Java OpenDiscogs Batch releases `1.0.0` through `1.2.1`.
+It covers canonical migrations V001 through V007 and Liquibase `5.0.3`
+checksum version 9.
+
+[`legacy-liquibase-v1.json`](legacy-liquibase-v1.json) is the machine-readable
+source of truth. Its JSON shape is fixed by
+[`legacy-liquibase-v1.schema.json`](legacy-liquibase-v1.schema.json). The
+manifest binds every migration to the SHA-256 of the original canonical SQL
+bytes and to both released Liquibase changeset identities.
+
+## Adoption proof
+
+Liquibase identity is the complete `ID`, `AUTHOR`, and `FILENAME` tuple. An
+adopter must find exactly one matching row for every migration in one complete
+historical prefix. Missing rows, duplicate identities, unknown execution types,
+and histories newer than the selected model artifact fail closed.
+
+The public changelog has an exact checksum for each changeset. Its `EXECUTED`
+rows require that checksum. The custom-schema changelog uses `modifySql` with
+the `databaseSchema` parameter, so its checksum changes with the schema name and
+is never independent proof of canonical state.
+
+V001, V002, V003, V005, and V006 may legitimately be `MARK_RAN` because their
+released preconditions used `onFail="MARK_RAN"`. V004 and V007 may only be
+`EXECUTED`. Every permitted `MARK_RAN` row and every custom-schema row requires
+schema validation in addition to its history identity.
+
+## Schema validation
+
+Released Java histories end at V004, V006, or V007. Each prefix in the manifest
+references the same immutable
+[`legacy-schema-fingerprint-v1.sql`](legacy-schema-fingerprint-v1.sql) verifier
+and a distinct expected fingerprint.
+
+The adopter must:
+
+1. hold the shared schema-migration lock and exclude legacy Liquibase writers;
+2. set `search_path` to the quoted target schema followed by `public`;
+3. execute the verifier and read its single `fingerprint_input` text value;
+4. compute lowercase SHA-256 over the UTF-8 bytes without adding a newline;
+5. compare it with the selected prefix and PostgreSQL major in the manifest;
+6. insert canonical filename and raw-SQL SHA-256 rows into the shared ledger in
+   the same transaction.
+
+The fingerprint includes canonical relations, columns, defaults, constraints,
+views, owned sequences, unique indexes, and canonical explicit indexes. It
+ignores unrelated tables and additional non-unique DBA indexes. PostgreSQL 15,
+16, 17, and 18 are explicitly represented because PostgreSQL 18 renders parts
+of the catalog differently. An unlisted PostgreSQL major requires a new model
+contract and must not reuse another major's fingerprint.
+
+## Safety boundary
+
+The contract proves that the current catalog matches a released canonical
+prefix; it does not prove who created that catalog. It does not validate object
+ownership, grants, unrelated objects, additional non-unique indexes, or user
+data beyond enforced and validated constraints. A forged `DATABASECHANGELOG`
+row cannot bypass the required fingerprint, but a database that was manually
+made catalog-equivalent is intentionally indistinguishable from one produced by
+the released migration.
+
+Adoption must stop for any mismatch. Repairing a partial legacy schema, choosing
+whether to preserve non-canonical objects, and approving a future PostgreSQL
+major remain explicit operator actions rather than automatic inference.

--- a/schema/contracts/legacy-liquibase-v1.schema.json
+++ b/schema/contracts/legacy-liquibase-v1.schema.json
@@ -1,0 +1,283 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/dsub-io/open-discogs-model/schema/contracts/legacy-liquibase-v1.schema.json",
+  "title": "OpenDiscogs legacy Liquibase compatibility manifest v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "formatVersion",
+    "contract",
+    "schemaDefinition",
+    "liquibaseVersion",
+    "liquibaseChecksumVersion",
+    "schemaContracts",
+    "migrations"
+  ],
+  "properties": {
+    "formatVersion": {
+      "const": 1
+    },
+    "contract": {
+      "const": "open-discogs-legacy-liquibase/v1"
+    },
+    "schemaDefinition": {
+      "$ref": "#/$defs/resource"
+    },
+    "liquibaseVersion": {
+      "const": "5.0.3"
+    },
+    "liquibaseChecksumVersion": {
+      "const": 9
+    },
+    "schemaContracts": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/schemaContract"
+      }
+    },
+    "migrations": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/migration"
+      }
+    }
+  },
+  "$defs": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "migrationVersion": {
+      "type": "string",
+      "pattern": "^V[0-9]{3}$"
+    },
+    "resource": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "sha256"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "sha256": {
+          "$ref": "#/$defs/sha256"
+        }
+      }
+    },
+    "schemaFingerprint": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "postgresMajor",
+        "sha256"
+      ],
+      "properties": {
+        "postgresMajor": {
+          "type": "integer",
+          "minimum": 15,
+          "maximum": 18
+        },
+        "sha256": {
+          "$ref": "#/$defs/sha256"
+        }
+      }
+    },
+    "schemaContract": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "prefix",
+        "migrationVersions",
+        "verifier",
+        "expectedFingerprints"
+      ],
+      "properties": {
+        "prefix": {
+          "$ref": "#/$defs/migrationVersion"
+        },
+        "migrationVersions": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/migrationVersion"
+          }
+        },
+        "verifier": {
+          "$ref": "#/$defs/resource"
+        },
+        "expectedFingerprints": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/schemaFingerprint"
+          }
+        }
+      }
+    },
+    "executionPolicy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "executionType",
+        "adoptionProof"
+      ],
+      "properties": {
+        "executionType": {
+          "enum": [
+            "EXECUTED",
+            "MARK_RAN"
+          ]
+        },
+        "adoptionProof": {
+          "enum": [
+            "EXACT_CHECKSUM",
+            "SCHEMA_CONTRACT"
+          ]
+        }
+      }
+    },
+    "legacyChangeSet": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schemaMode",
+        "id",
+        "author",
+        "filename",
+        "checksumPolicy",
+        "executionPolicies"
+      ],
+      "properties": {
+        "schemaMode": {
+          "enum": [
+            "PUBLIC",
+            "CUSTOM"
+          ]
+        },
+        "id": {
+          "type": "string",
+          "pattern": "^open-discogs-model-v[0-9]{3}$"
+        },
+        "author": {
+          "const": "state303"
+        },
+        "filename": {
+          "enum": [
+            "db/changelog/db.changelog-master.xml",
+            "db/changelog/db.changelog-custom-schema.xml"
+          ]
+        },
+        "checksumPolicy": {
+          "enum": [
+            "EXACT",
+            "SCHEMA_PARAMETERIZED"
+          ]
+        },
+        "checksum": {
+          "type": "string",
+          "pattern": "^9:[0-9a-f]{32}$"
+        },
+        "schemaParameter": {
+          "type": "string",
+          "const": "databaseSchema"
+        },
+        "executionPolicies": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 2,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/executionPolicy"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "checksumPolicy": {
+                "const": "EXACT"
+              }
+            },
+            "required": [
+              "checksumPolicy"
+            ]
+          },
+          "then": {
+            "required": [
+              "checksum"
+            ],
+            "not": {
+              "required": [
+                "schemaParameter"
+              ]
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "checksumPolicy": {
+                "const": "SCHEMA_PARAMETERIZED"
+              }
+            },
+            "required": [
+              "checksumPolicy"
+            ]
+          },
+          "then": {
+            "required": [
+              "schemaParameter"
+            ],
+            "not": {
+              "required": [
+                "checksum"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "migration": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "version",
+        "canonicalFilename",
+        "canonicalSha256",
+        "legacyChangeSets"
+      ],
+      "properties": {
+        "version": {
+          "$ref": "#/$defs/migrationVersion"
+        },
+        "canonicalFilename": {
+          "type": "string",
+          "pattern": "^V[0-9]{3}__[a-z0-9_]+\\.sql$"
+        },
+        "canonicalSha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "legacyChangeSets": {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/legacyChangeSet"
+          }
+        }
+      }
+    }
+  }
+}

--- a/schema/contracts/legacy-schema-fingerprint-v1.sql
+++ b/schema/contracts/legacy-schema-fingerprint-v1.sql
@@ -1,0 +1,188 @@
+-- Produces the canonical PostgreSQL catalog fingerprint for a legacy prefix.
+-- The caller must set search_path to the target schema before executing this query.
+with target_schema(schema_name) as (
+    select current_schema()
+),
+relation_names(relation_name) as (
+    values
+        ('artist'),
+        ('artist_alias'),
+        ('artist_group'),
+        ('artist_member'),
+        ('artist_name_variation'),
+        ('artist_url'),
+        ('discogs_dump'),
+        ('discogs_import_checkpoint'),
+        ('discogs_import_run'),
+        ('discogs_import_run_chunk'),
+        ('discogs_import_run_dump'),
+        ('genre'),
+        ('label'),
+        ('label_release_item'),
+        ('label_sub_label'),
+        ('label_url'),
+        ('master'),
+        ('master_artist'),
+        ('master_genre'),
+        ('master_style'),
+        ('master_video'),
+        ('release_item'),
+        ('release_item_artist'),
+        ('release_item_credited_artist'),
+        ('release_item_format'),
+        ('release_item_genre'),
+        ('release_item_identifier'),
+        ('release_item_image'),
+        ('release_item_style'),
+        ('release_item_track'),
+        ('release_item_video'),
+        ('release_item_work'),
+        ('style')
+),
+explicit_index_names(index_name) as (
+    values
+        ('ix_discogs_dump_date'),
+        ('ix_discogs_dump_etag'),
+        ('ix_discogs_import_run_dump_dump_id'),
+        ('ix_discogs_import_run_manifest_running'),
+        ('ix_discogs_import_run_manifest_success'),
+        ('ix_artist_name_trgm'),
+        ('ix_artist_real_name_trgm'),
+        ('ix_label_name_trgm'),
+        ('ix_master_title_trgm'),
+        ('ix_release_item_title_trgm'),
+        ('ix_master_year_id'),
+        ('ix_release_item_country_id'),
+        ('ix_release_item_release_date_id'),
+        ('ix_release_item_is_master_id'),
+        ('ix_release_item_master_id_id'),
+        ('ix_release_item_artist_artist_release'),
+        ('ix_release_item_credited_artist_artist_release'),
+        ('ix_label_release_item_label_release'),
+        ('ix_label_sub_label_sub_parent')
+),
+relations as (
+    select relation.oid, relation.relname, relation.relkind, relation.relpersistence
+    from pg_class relation
+    join pg_namespace namespace on namespace.oid = relation.relnamespace
+    join target_schema target on target.schema_name = namespace.nspname
+    join relation_names expected on expected.relation_name = relation.relname
+),
+descriptors(kind, object_name, definition) as (
+    select
+        'relation',
+        relation.relname,
+        relation.relkind::text || '|' || relation.relpersistence::text
+    from relations relation
+
+    union all
+
+    select
+        'column',
+        relation.relname || '.' || attribute.attname,
+        format_type(attribute.atttypid, attribute.atttypmod)
+            || '|' || attribute.attnotnull::text
+            || '|' || attribute.attidentity::text
+            || '|' || attribute.attgenerated::text
+            || '|' || coalesce(
+                replace(
+                    pg_get_expr(default_value.adbin, default_value.adrelid),
+                    target.schema_name || '.',
+                    '<schema>.'
+                ),
+                ''
+            )
+    from relations relation
+    join pg_attribute attribute
+        on attribute.attrelid = relation.oid
+       and attribute.attnum > 0
+       and not attribute.attisdropped
+    cross join target_schema target
+    left join pg_attrdef default_value
+        on default_value.adrelid = attribute.attrelid
+       and default_value.adnum = attribute.attnum
+
+    union all
+
+    select
+        'constraint',
+        relation.relname || '.' || constraint_definition.conname,
+        constraint_definition.contype::text
+            || '|' || constraint_definition.convalidated::text
+            || '|' || replace(
+                pg_get_constraintdef(constraint_definition.oid, false),
+                target.schema_name || '.',
+                '<schema>.'
+            )
+    from relations relation
+    join pg_constraint constraint_definition
+        on constraint_definition.conrelid = relation.oid
+    cross join target_schema target
+
+    union all
+
+    select
+        'index',
+        relation.relname || '.' || index_relation.relname,
+        index_metadata.indisunique::text
+            || '|' || index_metadata.indisprimary::text
+            || '|' || index_metadata.indisvalid::text
+            || '|' || index_metadata.indisready::text
+            || '|' || replace(
+                pg_get_indexdef(index_metadata.indexrelid),
+                target.schema_name || '.',
+                '<schema>.'
+            )
+    from relations relation
+    join pg_index index_metadata on index_metadata.indrelid = relation.oid
+    join pg_class index_relation on index_relation.oid = index_metadata.indexrelid
+    cross join target_schema target
+    where index_metadata.indisunique
+       or index_relation.relname in (select index_name from explicit_index_names)
+
+    union all
+
+    select
+        'sequence',
+        sequence_relation.relname,
+        format_type(sequence_metadata.seqtypid, -1)
+            || '|' || sequence_metadata.seqstart::text
+            || '|' || sequence_metadata.seqincrement::text
+            || '|' || sequence_metadata.seqmin::text
+            || '|' || sequence_metadata.seqmax::text
+            || '|' || sequence_metadata.seqcache::text
+            || '|' || sequence_metadata.seqcycle::text
+    from relations relation
+    join pg_depend dependency
+        on dependency.refclassid = 'pg_class'::regclass
+       and dependency.refobjid = relation.oid
+       and dependency.classid = 'pg_class'::regclass
+       and dependency.deptype in ('a', 'i')
+    join pg_class sequence_relation
+        on sequence_relation.oid = dependency.objid
+       and sequence_relation.relkind = 'S'
+    join pg_sequence sequence_metadata on sequence_metadata.seqrelid = sequence_relation.oid
+
+    union all
+
+    select
+        'view',
+        relation.relname,
+        replace(
+            regexp_replace(pg_get_viewdef(relation.oid, false), '\s+', ' ', 'g'),
+            target.schema_name || '.',
+            '<schema>.'
+        )
+    from relations relation
+    cross join target_schema target
+    where relation.relkind = 'v'
+)
+select coalesce(
+    string_agg(
+        kind || chr(31) || object_name || chr(31) || definition,
+        chr(10)
+        order by kind, object_name, definition
+    ),
+    ''
+) as fingerprint_input
+from descriptors;

--- a/schema/embed_test.go
+++ b/schema/embed_test.go
@@ -27,6 +27,7 @@ func TestMigrations(t *testing.T) {
 		"V006__concurrent_import_progress.sql",
 		"V007__api_query_indexes.sql",
 		"V008__label_release_catalog_identity.sql",
+		"V009__release_convergence_contract.sql",
 	}
 	if len(entries) != len(want) {
 		t.Fatalf("migration count = %d, want %d", len(entries), len(want))

--- a/schema/legacy_liquibase.go
+++ b/schema/legacy_liquibase.go
@@ -1,0 +1,522 @@
+package schema
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"embed"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"path"
+	"strings"
+)
+
+const (
+	LegacyLiquibaseManifestResource  = "legacy-liquibase-v1.json"
+	LegacyLiquibaseSchemaResource    = "legacy-liquibase-v1.schema.json"
+	LegacySchemaFingerprintResource  = "legacy-schema-fingerprint-v1.sql"
+	legacyLiquibaseContractID        = "open-discogs-legacy-liquibase/v1"
+	legacyLiquibaseVersion           = "5.0.3"
+	legacyLiquibaseChecksumVersion   = 9
+	legacyLiquibaseFormatVersion     = 1
+	legacyLiquibaseMigrationCount    = 7
+	legacyLiquibaseAuthor            = "state303"
+	legacyLiquibasePublicFilename    = "db/changelog/db.changelog-master.xml"
+	legacyLiquibaseCustomFilename    = "db/changelog/db.changelog-custom-schema.xml"
+	legacyLiquibaseSchemaParameter   = "databaseSchema"
+	legacyMinimumPostgreSQLMajor     = 15
+	legacyMaximumPostgreSQLMajor     = 18
+	legacyLiquibaseChecksumPrefix    = "9:"
+	legacyLiquibaseChecksumHexLength = 32
+	legacyCanonicalChecksumHexLength = 64
+	legacySchemaContractPrefixCount  = 3
+)
+
+var historicalPublicChecksums = [...]string{
+	"9:21b43c01c07539940ef584360151932e",
+	"9:1fe2b5ca5132d441129f7734864389bb",
+	"9:b9d40e8e8cb0f59b0d15e764f7af4070",
+	"9:c500950a7ae85ad47ea9ba14c857df39",
+	"9:363a63d36fadeea4d0dc435601398341",
+	"9:c89cf57ca3b13c733e9db92d2c2935a8",
+	"9:f60af7da668a40343f647837995b87ec",
+}
+
+var historicalContractPrefixes = [...]int{4, 6, 7}
+
+//go:embed contracts/legacy-liquibase-v1.json
+var legacyLiquibaseManifestJSON []byte
+
+//go:embed contracts/legacy-liquibase-v1.json contracts/legacy-liquibase-v1.schema.json contracts/legacy-schema-fingerprint-v1.sql
+var legacyLiquibaseContractFiles embed.FS
+
+// LegacySchemaMode identifies the released Liquibase changelog path.
+type LegacySchemaMode string
+
+const (
+	LegacySchemaModePublic LegacySchemaMode = "PUBLIC"
+	LegacySchemaModeCustom LegacySchemaMode = "CUSTOM"
+)
+
+// LegacyChecksumPolicy describes whether a historical Liquibase checksum is fixed.
+type LegacyChecksumPolicy string
+
+const (
+	LegacyChecksumPolicyExact               LegacyChecksumPolicy = "EXACT"
+	LegacyChecksumPolicySchemaParameterized LegacyChecksumPolicy = "SCHEMA_PARAMETERIZED"
+)
+
+// LegacyExecutionType is an execution state emitted by the released changelogs.
+type LegacyExecutionType string
+
+const (
+	LegacyExecutionTypeExecuted LegacyExecutionType = "EXECUTED"
+	LegacyExecutionTypeMarkRan  LegacyExecutionType = "MARK_RAN"
+)
+
+// LegacyAdoptionProof is the additional evidence required before ledger adoption.
+type LegacyAdoptionProof string
+
+const (
+	LegacyAdoptionProofExactChecksum  LegacyAdoptionProof = "EXACT_CHECKSUM"
+	LegacyAdoptionProofSchemaContract LegacyAdoptionProof = "SCHEMA_CONTRACT"
+)
+
+// ContractResource identifies immutable bytes packaged with the model release.
+type ContractResource struct {
+	Name   string `json:"name"`
+	SHA256 string `json:"sha256"`
+}
+
+// LegacySchemaFingerprint binds a PostgreSQL major to a catalog fingerprint.
+type LegacySchemaFingerprint struct {
+	PostgreSQLMajor int    `json:"postgresMajor"`
+	SHA256          string `json:"sha256"`
+}
+
+// LegacySchemaContract validates one complete historical migration prefix.
+type LegacySchemaContract struct {
+	Prefix               string                    `json:"prefix"`
+	MigrationVersions    []string                  `json:"migrationVersions"`
+	Verifier             ContractResource          `json:"verifier"`
+	ExpectedFingerprints []LegacySchemaFingerprint `json:"expectedFingerprints"`
+}
+
+// LegacyExecutionPolicy defines whether a DATABASECHANGELOG state may be adopted.
+type LegacyExecutionPolicy struct {
+	ExecutionType LegacyExecutionType `json:"executionType"`
+	AdoptionProof LegacyAdoptionProof `json:"adoptionProof"`
+}
+
+// LegacyChangeSet identifies one released Liquibase changeset representation.
+type LegacyChangeSet struct {
+	SchemaMode        LegacySchemaMode        `json:"schemaMode"`
+	ID                string                  `json:"id"`
+	Author            string                  `json:"author"`
+	Filename          string                  `json:"filename"`
+	ChecksumPolicy    LegacyChecksumPolicy    `json:"checksumPolicy"`
+	Checksum          string                  `json:"checksum,omitempty"`
+	SchemaParameter   string                  `json:"schemaParameter,omitempty"`
+	ExecutionPolicies []LegacyExecutionPolicy `json:"executionPolicies"`
+}
+
+// LegacyLiquibaseMigration maps one legacy changeset to canonical SQL bytes.
+type LegacyLiquibaseMigration struct {
+	Version           string            `json:"version"`
+	CanonicalFilename string            `json:"canonicalFilename"`
+	CanonicalSHA256   string            `json:"canonicalSha256"`
+	LegacyChangeSets  []LegacyChangeSet `json:"legacyChangeSets"`
+}
+
+// LegacyLiquibaseManifest is the model-owned legacy adoption contract.
+type LegacyLiquibaseManifest struct {
+	FormatVersion            int                        `json:"formatVersion"`
+	Contract                 string                     `json:"contract"`
+	SchemaDefinition         ContractResource           `json:"schemaDefinition"`
+	LiquibaseVersion         string                     `json:"liquibaseVersion"`
+	LiquibaseChecksumVersion int                        `json:"liquibaseChecksumVersion"`
+	SchemaContracts          []LegacySchemaContract     `json:"schemaContracts"`
+	Migrations               []LegacyLiquibaseMigration `json:"migrations"`
+}
+
+type prefixedFS struct {
+	files  fs.FS
+	prefix string
+}
+
+// LegacyLiquibaseCompatibility loads and validates the packaged v1 contract.
+func LegacyLiquibaseCompatibility() (LegacyLiquibaseManifest, error) {
+	return ParseLegacyLiquibaseManifest(
+		legacyLiquibaseManifestJSON,
+		prefixedFS{files: migrationFiles, prefix: "migrations"},
+		prefixedFS{files: legacyLiquibaseContractFiles, prefix: "contracts"},
+	)
+}
+
+// ParseLegacyLiquibaseManifest parses a manifest against caller-provided resources.
+func ParseLegacyLiquibaseManifest(
+	manifestJSON []byte,
+	canonicalMigrations fs.FS,
+	contractResources fs.FS,
+) (LegacyLiquibaseManifest, error) {
+	if canonicalMigrations == nil {
+		return LegacyLiquibaseManifest{}, errors.New("canonical migration filesystem is required")
+	}
+	if contractResources == nil {
+		return LegacyLiquibaseManifest{}, errors.New("legacy contract filesystem is required")
+	}
+	manifest, err := decodeLegacyLiquibaseManifest(manifestJSON)
+	if err != nil {
+		return LegacyLiquibaseManifest{}, err
+	}
+	if err := validateLegacyLiquibaseManifest(manifest, canonicalMigrations, contractResources); err != nil {
+		return LegacyLiquibaseManifest{}, err
+	}
+	return manifest, nil
+}
+
+// LegacyLiquibaseContract returns a copy of one packaged compatibility resource.
+func LegacyLiquibaseContract(name string) ([]byte, error) {
+	if name != LegacyLiquibaseManifestResource &&
+		name != LegacyLiquibaseSchemaResource &&
+		name != LegacySchemaFingerprintResource {
+		return nil, fmt.Errorf("unknown legacy Liquibase contract resource %q", name)
+	}
+	content, _ := fs.ReadFile(
+		prefixedFS{files: legacyLiquibaseContractFiles, prefix: "contracts"},
+		name,
+	)
+	return bytes.Clone(content), nil
+}
+
+// SchemaContract returns the exact historical prefix contract when present.
+func (manifest LegacyLiquibaseManifest) SchemaContract(
+	prefix string,
+) (LegacySchemaContract, bool) {
+	for _, contract := range manifest.SchemaContracts {
+		if contract.Prefix == prefix {
+			return contract, true
+		}
+	}
+	return LegacySchemaContract{}, false
+}
+
+// ExpectedFingerprint returns the catalog fingerprint for a PostgreSQL major.
+func (contract LegacySchemaContract) ExpectedFingerprint(
+	postgresqlMajor int,
+) (string, bool) {
+	for _, fingerprint := range contract.ExpectedFingerprints {
+		if fingerprint.PostgreSQLMajor == postgresqlMajor {
+			return fingerprint.SHA256, true
+		}
+	}
+	return "", false
+}
+
+// ExecutionPolicy returns the proof required for a permitted Liquibase state.
+func (changeSet LegacyChangeSet) ExecutionPolicy(
+	executionType LegacyExecutionType,
+) (LegacyExecutionPolicy, bool) {
+	for _, policy := range changeSet.ExecutionPolicies {
+		if policy.ExecutionType == executionType {
+			return policy, true
+		}
+	}
+	return LegacyExecutionPolicy{}, false
+}
+
+func decodeLegacyLiquibaseManifest(data []byte) (LegacyLiquibaseManifest, error) {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	var manifest LegacyLiquibaseManifest
+	if err := decoder.Decode(&manifest); err != nil {
+		return LegacyLiquibaseManifest{}, fmt.Errorf("decode legacy Liquibase manifest: %w", err)
+	}
+	var trailing json.RawMessage
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return LegacyLiquibaseManifest{}, errors.New("decode legacy Liquibase manifest: trailing JSON value")
+		}
+		return LegacyLiquibaseManifest{}, fmt.Errorf("decode legacy Liquibase manifest trailer: %w", err)
+	}
+	return manifest, nil
+}
+
+func validateLegacyLiquibaseManifest(
+	manifest LegacyLiquibaseManifest,
+	canonicalMigrations fs.FS,
+	contractResources fs.FS,
+) error {
+	if manifest.FormatVersion != legacyLiquibaseFormatVersion {
+		return fmt.Errorf("legacy Liquibase format version = %d, want %d", manifest.FormatVersion, legacyLiquibaseFormatVersion)
+	}
+	if manifest.Contract != legacyLiquibaseContractID {
+		return fmt.Errorf("legacy Liquibase contract = %q, want %q", manifest.Contract, legacyLiquibaseContractID)
+	}
+	if manifest.LiquibaseVersion != legacyLiquibaseVersion {
+		return fmt.Errorf("legacy Liquibase version = %q, want %q", manifest.LiquibaseVersion, legacyLiquibaseVersion)
+	}
+	if manifest.LiquibaseChecksumVersion != legacyLiquibaseChecksumVersion {
+		return fmt.Errorf("legacy Liquibase checksum version = %d, want %d", manifest.LiquibaseChecksumVersion, legacyLiquibaseChecksumVersion)
+	}
+	if manifest.SchemaDefinition.Name != LegacyLiquibaseSchemaResource {
+		return fmt.Errorf("schema definition resource = %q, want %q", manifest.SchemaDefinition.Name, LegacyLiquibaseSchemaResource)
+	}
+	if err := validateContractResource(manifest.SchemaDefinition, contractResources); err != nil {
+		return fmt.Errorf("validate schema definition: %w", err)
+	}
+	if err := validateSchemaContracts(manifest.SchemaContracts, contractResources); err != nil {
+		return err
+	}
+	return validateLegacyMigrations(manifest.Migrations, canonicalMigrations)
+}
+
+func validateSchemaContracts(
+	contracts []LegacySchemaContract,
+	contractResources fs.FS,
+) error {
+	if len(contracts) != legacySchemaContractPrefixCount {
+		return fmt.Errorf("legacy schema contract count = %d, want %d", len(contracts), legacySchemaContractPrefixCount)
+	}
+	for contractIndex, expectedPrefixNumber := range historicalContractPrefixes {
+		contract := contracts[contractIndex]
+		expectedPrefix := migrationVersion(expectedPrefixNumber)
+		if contract.Prefix != expectedPrefix {
+			return fmt.Errorf("legacy schema contract[%d] prefix = %q, want %q", contractIndex, contract.Prefix, expectedPrefix)
+		}
+		if len(contract.MigrationVersions) != expectedPrefixNumber {
+			return fmt.Errorf("legacy schema contract %s migration count = %d, want %d", contract.Prefix, len(contract.MigrationVersions), expectedPrefixNumber)
+		}
+		for migrationIndex, version := range contract.MigrationVersions {
+			expectedVersion := migrationVersion(migrationIndex + 1)
+			if version != expectedVersion {
+				return fmt.Errorf("legacy schema contract %s migration[%d] = %q, want %q", contract.Prefix, migrationIndex, version, expectedVersion)
+			}
+		}
+		if contract.Verifier.Name != LegacySchemaFingerprintResource {
+			return fmt.Errorf("legacy schema contract %s verifier = %q, want %q", contract.Prefix, contract.Verifier.Name, LegacySchemaFingerprintResource)
+		}
+		if err := validateContractResource(contract.Verifier, contractResources); err != nil {
+			return fmt.Errorf("validate legacy schema contract %s verifier: %w", contract.Prefix, err)
+		}
+		if err := validateExpectedFingerprints(contract); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateExpectedFingerprints(contract LegacySchemaContract) error {
+	expectedCount := legacyMaximumPostgreSQLMajor - legacyMinimumPostgreSQLMajor + 1
+	if len(contract.ExpectedFingerprints) != expectedCount {
+		return fmt.Errorf("legacy schema contract %s fingerprint count = %d, want %d", contract.Prefix, len(contract.ExpectedFingerprints), expectedCount)
+	}
+	for index, fingerprint := range contract.ExpectedFingerprints {
+		expectedMajor := legacyMinimumPostgreSQLMajor + index
+		if fingerprint.PostgreSQLMajor != expectedMajor {
+			return fmt.Errorf("legacy schema contract %s PostgreSQL major[%d] = %d, want %d", contract.Prefix, index, fingerprint.PostgreSQLMajor, expectedMajor)
+		}
+		if !validLowerHex(fingerprint.SHA256, legacyCanonicalChecksumHexLength) {
+			return fmt.Errorf("legacy schema contract %s PostgreSQL %d fingerprint is not lowercase SHA-256", contract.Prefix, fingerprint.PostgreSQLMajor)
+		}
+	}
+	return nil
+}
+
+func validateLegacyMigrations(
+	migrations []LegacyLiquibaseMigration,
+	canonicalMigrations fs.FS,
+) error {
+	if len(migrations) != legacyLiquibaseMigrationCount {
+		return fmt.Errorf("legacy migration count = %d, want %d", len(migrations), legacyLiquibaseMigrationCount)
+	}
+	if err := validateMigrationInventory(migrations, canonicalMigrations); err != nil {
+		return err
+	}
+	seenCanonicalChecksums := make(map[string]struct{}, len(migrations))
+	for index, migration := range migrations {
+		expectedNumber := index + 1
+		expectedVersion := migrationVersion(expectedNumber)
+		if migration.Version != expectedVersion {
+			return fmt.Errorf("legacy migration[%d] version = %q, want %q", index, migration.Version, expectedVersion)
+		}
+		if !validCanonicalMigrationFilename(migration.CanonicalFilename, expectedVersion) {
+			return fmt.Errorf("legacy migration %s canonical filename = %q", migration.Version, migration.CanonicalFilename)
+		}
+		if !validLowerHex(migration.CanonicalSHA256, legacyCanonicalChecksumHexLength) {
+			return fmt.Errorf("legacy migration %s canonical checksum is not lowercase SHA-256", migration.Version)
+		}
+		if _, duplicate := seenCanonicalChecksums[migration.CanonicalSHA256]; duplicate {
+			return fmt.Errorf("duplicate canonical migration checksum %q", migration.CanonicalSHA256)
+		}
+		seenCanonicalChecksums[migration.CanonicalSHA256] = struct{}{}
+		migrationSQL, err := fs.ReadFile(canonicalMigrations, migration.CanonicalFilename)
+		if err != nil {
+			return fmt.Errorf("read canonical migration %s: %w", migration.CanonicalFilename, err)
+		}
+		if checksum(migrationSQL) != migration.CanonicalSHA256 {
+			return fmt.Errorf("canonical migration %s checksum mismatch", migration.CanonicalFilename)
+		}
+		if err := validateLegacyChangeSets(migration, expectedNumber); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateLegacyChangeSets(migration LegacyLiquibaseMigration, migrationNumber int) error {
+	if len(migration.LegacyChangeSets) != 2 {
+		return fmt.Errorf("legacy migration %s changeset count = %d, want 2", migration.Version, len(migration.LegacyChangeSets))
+	}
+	for index, changeSet := range migration.LegacyChangeSets {
+		expectedMode := LegacySchemaModePublic
+		expectedFilename := legacyLiquibasePublicFilename
+		expectedChecksumPolicy := LegacyChecksumPolicyExact
+		if index == 1 {
+			expectedMode = LegacySchemaModeCustom
+			expectedFilename = legacyLiquibaseCustomFilename
+			expectedChecksumPolicy = LegacyChecksumPolicySchemaParameterized
+		}
+		if changeSet.SchemaMode != expectedMode {
+			return fmt.Errorf("legacy migration %s changeset[%d] schema mode = %q, want %q", migration.Version, index, changeSet.SchemaMode, expectedMode)
+		}
+		expectedID := "open-discogs-model-" + strings.ToLower(migration.Version)
+		if changeSet.ID != expectedID || changeSet.Author != legacyLiquibaseAuthor || changeSet.Filename != expectedFilename {
+			return fmt.Errorf("legacy migration %s changeset[%d] identity is invalid", migration.Version, index)
+		}
+		if changeSet.ChecksumPolicy != expectedChecksumPolicy {
+			return fmt.Errorf("legacy migration %s changeset[%d] checksum policy = %q, want %q", migration.Version, index, changeSet.ChecksumPolicy, expectedChecksumPolicy)
+		}
+		if expectedMode == LegacySchemaModePublic {
+			if !validLiquibaseChecksum(changeSet.Checksum) {
+				return fmt.Errorf("legacy migration %s public checksum format is invalid", migration.Version)
+			}
+			if changeSet.Checksum != historicalPublicChecksums[migrationNumber-1] || changeSet.SchemaParameter != "" {
+				return fmt.Errorf("legacy migration %s public checksum contract is invalid", migration.Version)
+			}
+		} else if changeSet.Checksum != "" || changeSet.SchemaParameter != legacyLiquibaseSchemaParameter {
+			return fmt.Errorf("legacy migration %s custom checksum contract is invalid", migration.Version)
+		}
+		if err := validateExecutionPolicies(migration.Version, changeSet, migrationNumber); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateExecutionPolicies(
+	version string,
+	changeSet LegacyChangeSet,
+	migrationNumber int,
+) error {
+	markRanPermitted := migrationNumber == 1 || migrationNumber == 2 || migrationNumber == 3 || migrationNumber == 5 || migrationNumber == 6
+	expectedCount := 1
+	if markRanPermitted {
+		expectedCount = 2
+	}
+	if len(changeSet.ExecutionPolicies) != expectedCount {
+		return fmt.Errorf("legacy migration %s %s execution policy count = %d, want %d", version, changeSet.SchemaMode, len(changeSet.ExecutionPolicies), expectedCount)
+	}
+	for index, policy := range changeSet.ExecutionPolicies {
+		expectedType := LegacyExecutionTypeExecuted
+		if index == 1 {
+			expectedType = LegacyExecutionTypeMarkRan
+		}
+		if policy.ExecutionType != expectedType {
+			return fmt.Errorf("legacy migration %s %s execution policy[%d] type = %q, want %q", version, changeSet.SchemaMode, index, policy.ExecutionType, expectedType)
+		}
+		expectedProof := LegacyAdoptionProofSchemaContract
+		if changeSet.SchemaMode == LegacySchemaModePublic && policy.ExecutionType == LegacyExecutionTypeExecuted {
+			expectedProof = LegacyAdoptionProofExactChecksum
+		}
+		if policy.AdoptionProof != expectedProof {
+			return fmt.Errorf("legacy migration %s %s %s proof = %q, want %q", version, changeSet.SchemaMode, policy.ExecutionType, policy.AdoptionProof, expectedProof)
+		}
+	}
+	return nil
+}
+
+func validateContractResource(reference ContractResource, contractResources fs.FS) error {
+	if !validLowerHex(reference.SHA256, legacyCanonicalChecksumHexLength) {
+		return fmt.Errorf("contract resource %s checksum is not lowercase SHA-256", reference.Name)
+	}
+	content, err := fs.ReadFile(contractResources, reference.Name)
+	if err != nil {
+		return fmt.Errorf("read contract resource %s: %w", reference.Name, err)
+	}
+	if checksum(content) != reference.SHA256 {
+		return fmt.Errorf("contract resource %s checksum mismatch", reference.Name)
+	}
+	return nil
+}
+
+func validateMigrationInventory(
+	migrations []LegacyLiquibaseMigration,
+	canonicalMigrations fs.FS,
+) error {
+	entries, err := fs.ReadDir(canonicalMigrations, ".")
+	if err != nil {
+		return fmt.Errorf("read canonical migration inventory: %w", err)
+	}
+	if len(entries) < len(migrations) {
+		return fmt.Errorf("canonical migration inventory count = %d, need at least %d", len(entries), len(migrations))
+	}
+	for index, migration := range migrations {
+		entry := entries[index]
+		if entry.IsDir() || entry.Name() != migration.CanonicalFilename {
+			return fmt.Errorf("canonical migration inventory[%d] = %q, want file %q", index, entry.Name(), migration.CanonicalFilename)
+		}
+	}
+	return nil
+}
+
+func (rooted prefixedFS) Open(name string) (fs.File, error) {
+	if !fs.ValidPath(name) {
+		return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrInvalid}
+	}
+	return rooted.files.Open(path.Join(rooted.prefix, name))
+}
+
+func validLiquibaseChecksum(value string) bool {
+	return strings.HasPrefix(value, legacyLiquibaseChecksumPrefix) &&
+		validLowerHex(strings.TrimPrefix(value, legacyLiquibaseChecksumPrefix), legacyLiquibaseChecksumHexLength)
+}
+
+func validCanonicalMigrationFilename(filename string, version string) bool {
+	prefix := version + "__"
+	if !strings.HasPrefix(filename, prefix) || !strings.HasSuffix(filename, ".sql") {
+		return false
+	}
+	description := strings.TrimSuffix(strings.TrimPrefix(filename, prefix), ".sql")
+	if description == "" {
+		return false
+	}
+	for _, character := range description {
+		if (character < 'a' || character > 'z') &&
+			(character < '0' || character > '9') &&
+			character != '_' {
+			return false
+		}
+	}
+	return true
+}
+
+func validLowerHex(value string, expectedLength int) bool {
+	if len(value) != expectedLength || value != strings.ToLower(value) {
+		return false
+	}
+	_, err := hex.DecodeString(value)
+	return err == nil
+}
+
+func checksum(content []byte) string {
+	digest := sha256.Sum256(content)
+	return hex.EncodeToString(digest[:])
+}
+
+func migrationVersion(number int) string {
+	return fmt.Sprintf("V%03d", number)
+}

--- a/schema/legacy_liquibase_test.go
+++ b/schema/legacy_liquibase_test.go
@@ -1,0 +1,417 @@
+package schema
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io/fs"
+	"os"
+	"strings"
+	"testing"
+	"testing/fstest"
+)
+
+var errInjectedFileSystem = errors.New("injected filesystem failure")
+
+type failingFS struct{}
+
+func (failingFS) Open(string) (fs.File, error) {
+	return nil, errInjectedFileSystem
+}
+
+type selectiveFailureFS struct {
+	files    fs.FS
+	failName string
+}
+
+func (filesystem selectiveFailureFS) Open(name string) (fs.File, error) {
+	if name == filesystem.failName {
+		return nil, errInjectedFileSystem
+	}
+	return filesystem.files.Open(name)
+}
+
+func TestLegacyLiquibaseCompatibilityPackageResources(t *testing.T) {
+	t.Parallel()
+
+	manifest, err := LegacyLiquibaseCompatibility()
+	if err != nil {
+		t.Fatalf("LegacyLiquibaseCompatibility() error = %v", err)
+	}
+	if len(manifest.Migrations) != legacyLiquibaseMigrationCount {
+		t.Fatalf("migration count = %d, want %d", len(manifest.Migrations), legacyLiquibaseMigrationCount)
+	}
+	if _, err := Migrations(); err != nil {
+		t.Fatalf("Migrations() error = %v", err)
+	}
+
+	resourceNames := []string{
+		LegacyLiquibaseManifestResource,
+		LegacyLiquibaseSchemaResource,
+		LegacySchemaFingerprintResource,
+	}
+	for _, resourceName := range resourceNames {
+		packaged, resourceErr := LegacyLiquibaseContract(resourceName)
+		if resourceErr != nil {
+			t.Fatalf("LegacyLiquibaseContract(%q) error = %v", resourceName, resourceErr)
+		}
+		disk, readErr := os.ReadFile("contracts/" + resourceName)
+		if readErr != nil {
+			t.Fatalf("ReadFile(%q) error = %v", resourceName, readErr)
+		}
+		if !bytes.Equal(packaged, disk) {
+			t.Errorf("packaged resource %q differs from schema/contracts", resourceName)
+		}
+		if len(packaged) == 0 {
+			t.Errorf("packaged resource %q is empty", resourceName)
+		}
+		packaged[0] ^= 0xff
+		again, secondErr := LegacyLiquibaseContract(resourceName)
+		if secondErr != nil {
+			t.Fatalf("second LegacyLiquibaseContract(%q) error = %v", resourceName, secondErr)
+		}
+		if bytes.Equal(packaged, again) {
+			t.Errorf("LegacyLiquibaseContract(%q) returned shared mutable bytes", resourceName)
+		}
+	}
+	if _, err := LegacyLiquibaseContract("unknown.json"); err == nil {
+		t.Error("LegacyLiquibaseContract() accepted an unknown resource")
+	}
+	if !json.Valid(mustContract(t, LegacyLiquibaseManifestResource)) {
+		t.Error("packaged legacy manifest is not valid JSON")
+	}
+	if !json.Valid(mustContract(t, LegacyLiquibaseSchemaResource)) {
+		t.Error("packaged legacy JSON schema is not valid JSON")
+	}
+	verifier := string(mustContract(t, LegacySchemaFingerprintResource))
+	if !strings.Contains(verifier, "current_schema()") || !strings.Contains(verifier, "fingerprint_input") {
+		t.Error("packaged fingerprint verifier does not expose the documented SQL contract")
+	}
+}
+
+func TestLegacyLiquibaseCompatibilityLookups(t *testing.T) {
+	t.Parallel()
+
+	manifest := mustManifest(t)
+	contract, found := manifest.SchemaContract("V007")
+	if !found || contract.Prefix != "V007" {
+		t.Fatalf("SchemaContract(V007) = %#v, %t", contract, found)
+	}
+	if _, found := manifest.SchemaContract("V999"); found {
+		t.Error("SchemaContract(V999) unexpectedly succeeded")
+	}
+	fingerprint, found := contract.ExpectedFingerprint(18)
+	if !found || fingerprint != "833cdf351ec53874c1cc244578e3aac2e0b87bcb68f8228b0d4286977d190d13" {
+		t.Fatalf("ExpectedFingerprint(18) = %q, %t", fingerprint, found)
+	}
+	if _, found := contract.ExpectedFingerprint(19); found {
+		t.Error("ExpectedFingerprint(19) unexpectedly succeeded")
+	}
+	policy, found := manifest.Migrations[0].LegacyChangeSets[0].ExecutionPolicy(
+		LegacyExecutionTypeMarkRan,
+	)
+	if !found || policy.AdoptionProof != LegacyAdoptionProofSchemaContract {
+		t.Fatalf("ExecutionPolicy(MARK_RAN) = %#v, %t", policy, found)
+	}
+	if _, found := manifest.Migrations[0].LegacyChangeSets[0].ExecutionPolicy("FAILED"); found {
+		t.Error("ExecutionPolicy(FAILED) unexpectedly succeeded")
+	}
+}
+
+func TestPrefixedFS(t *testing.T) {
+	t.Parallel()
+
+	rooted := prefixedFS{
+		files: fstest.MapFS{
+			"root/value.txt": &fstest.MapFile{Data: []byte("value")},
+		},
+		prefix: "root",
+	}
+	value, err := fs.ReadFile(rooted, "value.txt")
+	if err != nil || string(value) != "value" {
+		t.Fatalf("ReadFile() = %q, %v", value, err)
+	}
+	if _, err := rooted.Open("../value.txt"); !errors.Is(err, fs.ErrInvalid) {
+		t.Fatalf("Open(invalid) error = %v, want fs.ErrInvalid", err)
+	}
+}
+
+func TestParseLegacyLiquibaseManifestRejectsJSONErrors(t *testing.T) {
+	t.Parallel()
+
+	valid := mustContract(t, LegacyLiquibaseManifestResource)
+	unknown := bytes.Replace(valid, []byte("\"formatVersion\": 1,"), []byte("\"unknown\": true, \"formatVersion\": 1,"), 1)
+	cases := []struct {
+		name string
+		data []byte
+	}{
+		{name: "invalid document", data: []byte("{")},
+		{name: "unknown field", data: unknown},
+		{name: "trailing value", data: append(bytes.Clone(valid), []byte("\n{}")...)},
+		{name: "invalid trailer", data: append(bytes.Clone(valid), []byte("\n]")...)},
+	}
+	for _, testCase := range cases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := ParseLegacyLiquibaseManifest(
+				testCase.data,
+				validMigrationFS(t),
+				validContractFS(t),
+			); err == nil {
+				t.Error("ParseLegacyLiquibaseManifest() unexpectedly succeeded")
+			}
+		})
+	}
+}
+
+func TestParseLegacyLiquibaseManifestRequiresFilesystems(t *testing.T) {
+	t.Parallel()
+
+	manifest := mustContract(t, LegacyLiquibaseManifestResource)
+	if _, err := ParseLegacyLiquibaseManifest(manifest, nil, validContractFS(t)); err == nil {
+		t.Error("ParseLegacyLiquibaseManifest() accepted a nil migration filesystem")
+	}
+	if _, err := ParseLegacyLiquibaseManifest(manifest, validMigrationFS(t), nil); err == nil {
+		t.Error("ParseLegacyLiquibaseManifest() accepted a nil contract filesystem")
+	}
+}
+
+func TestValidCanonicalMigrationFilename(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		filename string
+		valid    bool
+	}{
+		{filename: "V001__initial_schema.sql", valid: true},
+		{filename: "V001_initial_schema.sql", valid: false},
+		{filename: "V001__.sql", valid: false},
+		{filename: "V001__Initial_schema.sql", valid: false},
+		{filename: "V001__initial-schema.sql", valid: false},
+	}
+	for _, testCase := range cases {
+		if got := validCanonicalMigrationFilename(testCase.filename, "V001"); got != testCase.valid {
+			t.Errorf("validCanonicalMigrationFilename(%q) = %t, want %t", testCase.filename, got, testCase.valid)
+		}
+	}
+}
+
+func TestLegacyLiquibaseManifestRejectsMetadataAndContractDrift(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		mutate func(*LegacyLiquibaseManifest)
+	}{
+		{name: "format version", mutate: func(value *LegacyLiquibaseManifest) { value.FormatVersion = 2 }},
+		{name: "contract", mutate: func(value *LegacyLiquibaseManifest) { value.Contract = "other" }},
+		{name: "Liquibase version", mutate: func(value *LegacyLiquibaseManifest) { value.LiquibaseVersion = "5.0.4" }},
+		{name: "checksum version", mutate: func(value *LegacyLiquibaseManifest) { value.LiquibaseChecksumVersion = 8 }},
+		{name: "schema resource name", mutate: func(value *LegacyLiquibaseManifest) { value.SchemaDefinition.Name = "other.json" }},
+		{name: "schema resource checksum length", mutate: func(value *LegacyLiquibaseManifest) { value.SchemaDefinition.SHA256 = "0" }},
+		{name: "schema resource checksum uppercase", mutate: func(value *LegacyLiquibaseManifest) { value.SchemaDefinition.SHA256 = strings.Repeat("A", 64) }},
+		{name: "schema resource checksum nonhex", mutate: func(value *LegacyLiquibaseManifest) { value.SchemaDefinition.SHA256 = strings.Repeat("g", 64) }},
+		{name: "schema resource checksum mismatch", mutate: func(value *LegacyLiquibaseManifest) { value.SchemaDefinition.SHA256 = strings.Repeat("0", 64) }},
+		{name: "schema contract count", mutate: func(value *LegacyLiquibaseManifest) { value.SchemaContracts = value.SchemaContracts[:2] }},
+		{name: "schema contract prefix", mutate: func(value *LegacyLiquibaseManifest) { value.SchemaContracts[0].Prefix = "V005" }},
+		{name: "schema contract migration count", mutate: func(value *LegacyLiquibaseManifest) {
+			value.SchemaContracts[0].MigrationVersions = value.SchemaContracts[0].MigrationVersions[:3]
+		}},
+		{name: "schema contract migration order", mutate: func(value *LegacyLiquibaseManifest) { value.SchemaContracts[0].MigrationVersions[0] = "V002" }},
+		{name: "schema contract verifier name", mutate: func(value *LegacyLiquibaseManifest) { value.SchemaContracts[0].Verifier.Name = "other.sql" }},
+		{name: "schema contract verifier mismatch", mutate: func(value *LegacyLiquibaseManifest) {
+			value.SchemaContracts[0].Verifier.SHA256 = strings.Repeat("0", 64)
+		}},
+		{name: "fingerprint count", mutate: func(value *LegacyLiquibaseManifest) {
+			value.SchemaContracts[0].ExpectedFingerprints = value.SchemaContracts[0].ExpectedFingerprints[:3]
+		}},
+		{name: "fingerprint major", mutate: func(value *LegacyLiquibaseManifest) {
+			value.SchemaContracts[0].ExpectedFingerprints[0].PostgreSQLMajor = 14
+		}},
+		{name: "fingerprint checksum", mutate: func(value *LegacyLiquibaseManifest) {
+			value.SchemaContracts[0].ExpectedFingerprints[0].SHA256 = "invalid"
+		}},
+	}
+	for _, testCase := range cases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			manifest := cloneManifest(t, mustManifest(t))
+			testCase.mutate(&manifest)
+			assertManifestRejected(t, manifest, validMigrationFS(t), validContractFS(t))
+		})
+	}
+}
+
+func TestLegacyLiquibaseManifestRejectsMissingContractResources(t *testing.T) {
+	t.Parallel()
+
+	manifest := mustManifest(t)
+	contracts := validContractFS(t)
+	delete(contracts, LegacyLiquibaseSchemaResource)
+	assertManifestRejected(t, manifest, validMigrationFS(t), contracts)
+}
+
+func TestLegacyLiquibaseManifestRejectsMigrationDrift(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		mutate func(*LegacyLiquibaseManifest)
+	}{
+		{name: "migration count", mutate: func(value *LegacyLiquibaseManifest) { value.Migrations = value.Migrations[:6] }},
+		{name: "migration version", mutate: func(value *LegacyLiquibaseManifest) { value.Migrations[0].Version = "V002" }},
+		{name: "migration filename", mutate: func(value *LegacyLiquibaseManifest) { value.Migrations[0].CanonicalFilename = "V001.sql" }},
+		{name: "canonical checksum length", mutate: func(value *LegacyLiquibaseManifest) { value.Migrations[0].CanonicalSHA256 = "0" }},
+		{name: "duplicate canonical checksum", mutate: func(value *LegacyLiquibaseManifest) {
+			value.Migrations[1].CanonicalSHA256 = value.Migrations[0].CanonicalSHA256
+		}},
+		{name: "canonical checksum mismatch", mutate: func(value *LegacyLiquibaseManifest) { value.Migrations[0].CanonicalSHA256 = strings.Repeat("0", 64) }},
+		{name: "changeset count", mutate: func(value *LegacyLiquibaseManifest) {
+			value.Migrations[0].LegacyChangeSets = value.Migrations[0].LegacyChangeSets[:1]
+		}},
+		{name: "schema mode enum", mutate: func(value *LegacyLiquibaseManifest) { value.Migrations[0].LegacyChangeSets[0].SchemaMode = "UNKNOWN" }},
+		{name: "identity", mutate: func(value *LegacyLiquibaseManifest) { value.Migrations[0].LegacyChangeSets[0].Author = "other" }},
+		{name: "checksum policy enum", mutate: func(value *LegacyLiquibaseManifest) {
+			value.Migrations[0].LegacyChangeSets[0].ChecksumPolicy = "UNKNOWN"
+		}},
+		{name: "public checksum format", mutate: func(value *LegacyLiquibaseManifest) {
+			value.Migrations[0].LegacyChangeSets[0].Checksum = "8:21b43c01c07539940ef584360151932e"
+		}},
+		{name: "public checksum value", mutate: func(value *LegacyLiquibaseManifest) {
+			value.Migrations[0].LegacyChangeSets[0].Checksum = "9:00000000000000000000000000000000"
+		}},
+		{name: "custom checksum", mutate: func(value *LegacyLiquibaseManifest) {
+			value.Migrations[0].LegacyChangeSets[1].Checksum = "9:00000000000000000000000000000000"
+		}},
+		{name: "execution policy count", mutate: func(value *LegacyLiquibaseManifest) {
+			value.Migrations[0].LegacyChangeSets[0].ExecutionPolicies = value.Migrations[0].LegacyChangeSets[0].ExecutionPolicies[:1]
+		}},
+		{name: "execution type enum", mutate: func(value *LegacyLiquibaseManifest) {
+			value.Migrations[0].LegacyChangeSets[0].ExecutionPolicies[0].ExecutionType = "FAILED"
+		}},
+		{name: "adoption proof enum", mutate: func(value *LegacyLiquibaseManifest) {
+			value.Migrations[0].LegacyChangeSets[0].ExecutionPolicies[0].AdoptionProof = "UNKNOWN"
+		}},
+	}
+	for _, testCase := range cases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			manifest := cloneManifest(t, mustManifest(t))
+			testCase.mutate(&manifest)
+			assertManifestRejected(t, manifest, validMigrationFS(t), validContractFS(t))
+		})
+	}
+}
+
+func TestLegacyLiquibaseManifestRejectsMigrationInventoryFailures(t *testing.T) {
+	t.Parallel()
+
+	manifest := mustManifest(t)
+	assertManifestRejected(t, manifest, failingFS{}, validContractFS(t))
+
+	shortInventory := validMigrationFS(t)
+	delete(shortInventory, manifest.Migrations[6].CanonicalFilename)
+	assertManifestRejected(t, manifest, shortInventory, validContractFS(t))
+
+	wrongInventory := validMigrationFS(t)
+	delete(wrongInventory, manifest.Migrations[0].CanonicalFilename)
+	wrongInventory["A000__wrong.sql"] = &fstest.MapFile{Data: []byte("wrong")}
+	assertManifestRejected(t, manifest, wrongInventory, validContractFS(t))
+
+	directoryInventory := validMigrationFS(t)
+	directoryInventory[manifest.Migrations[0].CanonicalFilename] = &fstest.MapFile{Mode: fs.ModeDir}
+	assertManifestRejected(t, manifest, directoryInventory, validContractFS(t))
+
+	readFailure := selectiveFailureFS{
+		files:    validMigrationFS(t),
+		failName: manifest.Migrations[0].CanonicalFilename,
+	}
+	assertManifestRejected(t, manifest, readFailure, validContractFS(t))
+
+	invalidFilenameManifest := cloneManifest(t, manifest)
+	originalFilename := invalidFilenameManifest.Migrations[0].CanonicalFilename
+	invalidFilenameManifest.Migrations[0].CanonicalFilename = "V001__initial_schema.txt"
+	invalidFilenameInventory := validMigrationFS(t)
+	invalidFilenameInventory[invalidFilenameManifest.Migrations[0].CanonicalFilename] =
+		invalidFilenameInventory[originalFilename]
+	delete(invalidFilenameInventory, originalFilename)
+	assertManifestRejected(
+		t,
+		invalidFilenameManifest,
+		invalidFilenameInventory,
+		validContractFS(t),
+	)
+}
+
+func mustManifest(t *testing.T) LegacyLiquibaseManifest {
+	t.Helper()
+	manifest, err := LegacyLiquibaseCompatibility()
+	if err != nil {
+		t.Fatalf("LegacyLiquibaseCompatibility() error = %v", err)
+	}
+	return manifest
+}
+
+func cloneManifest(t *testing.T, source LegacyLiquibaseManifest) LegacyLiquibaseManifest {
+	t.Helper()
+	encoded, err := json.Marshal(source)
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	var clone LegacyLiquibaseManifest
+	if err := json.Unmarshal(encoded, &clone); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	return clone
+}
+
+func assertManifestRejected(
+	t *testing.T,
+	manifest LegacyLiquibaseManifest,
+	migrations fs.FS,
+	contracts fs.FS,
+) {
+	t.Helper()
+	encoded, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	if _, err := ParseLegacyLiquibaseManifest(encoded, migrations, contracts); err == nil {
+		t.Error("ParseLegacyLiquibaseManifest() unexpectedly succeeded")
+	}
+}
+
+func validMigrationFS(t *testing.T) fstest.MapFS {
+	t.Helper()
+	manifest := mustManifest(t)
+	migrations := make(fstest.MapFS, len(manifest.Migrations))
+	for _, migration := range manifest.Migrations {
+		content, err := migrationFiles.ReadFile("migrations/" + migration.CanonicalFilename)
+		if err != nil {
+			t.Fatalf("ReadFile(%q) error = %v", migration.CanonicalFilename, err)
+		}
+		migrations[migration.CanonicalFilename] = &fstest.MapFile{Data: bytes.Clone(content)}
+	}
+	return migrations
+}
+
+func validContractFS(t *testing.T) fstest.MapFS {
+	t.Helper()
+	contracts := make(fstest.MapFS, 2)
+	for _, name := range []string{LegacyLiquibaseSchemaResource, LegacySchemaFingerprintResource} {
+		contracts[name] = &fstest.MapFile{Data: mustContract(t, name)}
+	}
+	return contracts
+}
+
+func mustContract(t *testing.T, name string) []byte {
+	t.Helper()
+	content, err := LegacyLiquibaseContract(name)
+	if err != nil {
+		t.Fatalf("LegacyLiquibaseContract(%q) error = %v", name, err)
+	}
+	return content
+}

--- a/schema/migrations/V009__release_convergence_contract.sql
+++ b/schema/migrations/V009__release_convergence_contract.sql
@@ -1,0 +1,47 @@
+alter table public.discogs_import_run_dump
+    add column import_contract_revision integer not null default 1;
+
+alter table public.discogs_import_run_dump
+    alter column import_contract_revision drop default,
+    add constraint ck_discogs_import_run_dump_import_contract_revision_positive
+        check (import_contract_revision > 0);
+
+comment on column public.discogs_import_run_dump.import_contract_revision is
+    'Entity semantics revision: pre-V009 rows are 1; V009 uses artist=1, label=1, master=1, release=2 and requires an explicit value.';
+
+alter table public.release_item
+    add constraint uq_release_item_master_id_id
+        unique (master_id, id);
+
+drop index public.ix_release_item_master_id_id;
+
+alter table public.master
+    drop constraint fk_master_main_release_id_release_item,
+    add constraint uq_master_main_release_id
+        unique (main_release_id),
+    add constraint fk_master_id_main_release_id_release_item_master_id_id
+        foreign key (id, main_release_id)
+            references public.release_item (master_id, id)
+            deferrable initially immediate;
+
+create function public.clear_stale_main_release_before_release_master_change()
+returns trigger
+language plpgsql
+security invoker
+set search_path = pg_catalog
+as $trigger$
+begin
+    update public.master
+    set main_release_id = null
+    where id = old.master_id
+      and main_release_id = old.id;
+
+    return new;
+end
+$trigger$;
+
+create trigger trg_release_item_clear_stale_main_release
+before update of master_id on public.release_item
+for each row
+when (old.master_id is distinct from new.master_id)
+execute function public.clear_stale_main_release_before_release_master_change();

--- a/scripts/test-release-convergence-contract.sh
+++ b/scripts/test-release-convergence-contract.sh
@@ -1,0 +1,606 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repository_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+test_owner="open-discogs-model"
+test_suite="release-convergence-contract"
+test_run="$(date -u +%Y%m%dT%H%M%SZ)-$$"
+postgres_images=("postgres:15.13-alpine" "postgres:18.4-alpine")
+container_names=()
+created_volume_names=()
+
+cleanup() {
+  local cleanup_status=0
+  local container_name
+  local actual_owner
+  local actual_suite
+  local actual_run
+  local resource_ids
+  local volume_name
+
+  for container_name in ${container_names[@]+"${container_names[@]}"}; do
+    if ! docker container inspect "$container_name" >/dev/null 2>&1; then
+      continue
+    fi
+    actual_owner="$(docker container inspect \
+      --format '{{index .Config.Labels "io.dsub.test-owner"}}' "$container_name")"
+    actual_suite="$(docker container inspect \
+      --format '{{index .Config.Labels "io.dsub.test-suite"}}' "$container_name")"
+    actual_run="$(docker container inspect \
+      --format '{{index .Config.Labels "io.dsub.test-run"}}' "$container_name")"
+    if [[ "$actual_owner" != "$test_owner" \
+      || "$actual_suite" != "$test_suite" \
+      || "$actual_run" != "$test_run" ]]; then
+      printf 'Refusing to clean container with unexpected ownership: %s\n' \
+        "$container_name" >&2
+      cleanup_status=1
+      continue
+    fi
+    docker container rm --force --volumes "$container_name" >/dev/null \
+      || cleanup_status=1
+  done
+
+  for volume_name in ${created_volume_names[@]+"${created_volume_names[@]}"}; do
+    if docker volume inspect "$volume_name" >/dev/null 2>&1; then
+      docker volume rm "$volume_name" >/dev/null || cleanup_status=1
+    fi
+  done
+
+  resource_ids="$(docker container ls --all --quiet \
+    --filter "label=io.dsub.test-owner=$test_owner" \
+    --filter "label=io.dsub.test-suite=$test_suite" \
+    --filter "label=io.dsub.test-run=$test_run")"
+  if [[ -n "$resource_ids" ]]; then
+    printf 'Docker container residue remains for test run %s: %s\n' \
+      "$test_run" "$resource_ids" >&2
+    cleanup_status=1
+  fi
+
+  for resource_type in network volume; do
+    resource_ids="$(docker "$resource_type" ls --quiet \
+      --filter "label=io.dsub.test-owner=$test_owner" \
+      --filter "label=io.dsub.test-suite=$test_suite" \
+      --filter "label=io.dsub.test-run=$test_run")"
+    if [[ -n "$resource_ids" ]]; then
+      printf 'Docker %s residue remains for test run %s: %s\n' \
+        "$resource_type" "$test_run" "$resource_ids" >&2
+      cleanup_status=1
+    fi
+  done
+
+  return "$cleanup_status"
+}
+
+on_exit() {
+  local test_status=$?
+  trap - EXIT HUP INT TERM
+  if ! cleanup; then
+    test_status=1
+  fi
+  if [[ "$test_status" == 0 ]]; then
+    printf 'Docker cleanup and residue verification passed for %s\n' "$test_run"
+  fi
+  exit "$test_status"
+}
+
+trap on_exit EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+wait_for_postgres() {
+  local container_name=$1
+
+  for _ in {1..30}; do
+    if docker exec "$container_name" \
+      psql --username postgres --dbname postgres \
+      --no-psqlrc --tuples-only --command 'select 1' >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+  done
+  printf 'PostgreSQL did not become ready: %s\n' "$container_name" >&2
+  return 1
+}
+
+apply_migrations_through_v008() {
+  local container_name=$1
+  local database_name=$2
+  local version
+  local migration
+
+  for version in 001 002 003 004 005 006 007 008; do
+    migration="$(find "$repository_root/schema/migrations" \
+      -maxdepth 1 -type f -name "V${version}__*.sql" -print -quit)"
+    if [[ -z "$migration" ]]; then
+      printf 'Missing migration V%s\n' "$version" >&2
+      return 1
+    fi
+    docker exec --interactive "$container_name" \
+      psql --username postgres --dbname "$database_name" \
+      --no-psqlrc --set ON_ERROR_STOP=1 --single-transaction \
+      < "$migration" >/dev/null
+  done
+}
+
+apply_v009() {
+  local container_name=$1
+  local database_name=$2
+
+  docker exec --interactive "$container_name" \
+    psql --username postgres --dbname "$database_name" \
+    --no-psqlrc --set ON_ERROR_STOP=1 --single-transaction \
+    < "$repository_root/schema/migrations/V009__release_convergence_contract.sql" \
+    >/dev/null
+}
+
+execute_sql() {
+  local container_name=$1
+  local database_name=$2
+  local statement=$3
+
+  docker exec "$container_name" \
+    psql --username postgres --dbname "$database_name" \
+    --no-psqlrc --set ON_ERROR_STOP=1 --command "$statement" >/dev/null
+}
+
+assert_scalar() {
+  local container_name=$1
+  local database_name=$2
+  local query=$3
+  local expected=$4
+  local actual
+
+  actual="$(docker exec "$container_name" \
+    psql --username postgres --dbname "$database_name" \
+    --no-psqlrc --no-align --tuples-only --set ON_ERROR_STOP=1 \
+    --command "$query")"
+  if [[ "$actual" != "$expected" ]]; then
+    printf 'Unexpected query result in %s: expected %s, got %s\n' \
+      "$database_name" "$expected" "$actual" >&2
+    return 1
+  fi
+}
+
+expect_sql_failure() {
+  local container_name=$1
+  local database_name=$2
+  local statement=$3
+
+  if docker exec "$container_name" \
+    psql --username postgres --dbname "$database_name" \
+    --no-psqlrc --set ON_ERROR_STOP=1 --command "$statement" \
+    >/dev/null 2>&1; then
+    printf 'Statement unexpectedly succeeded in %s: %s\n' \
+      "$database_name" "$statement" >&2
+    return 1
+  fi
+}
+
+seed_import_run() {
+  local container_name=$1
+  local database_name=$2
+
+  execute_sql "$container_name" "$database_name" "
+    insert into public.discogs_dump (
+      etag,
+      dump_date,
+      entity_type,
+      checksum_sha256,
+      size_bytes,
+      uri
+    ) values
+      ('artist-etag', date '2026-08-01', 'artist', repeat('1', 64), 1, '/artist'),
+      ('label-etag', date '2026-08-01', 'label', repeat('2', 64), 1, '/label'),
+      ('master-etag', date '2026-08-01', 'master', repeat('3', 64), 1, '/master'),
+      ('release-etag', date '2026-08-01', 'release', repeat('4', 64), 1, '/release');
+
+    with legacy_run as (
+      insert into public.discogs_import_run (
+        completed_at,
+        manifest_sha256,
+        status,
+        processor,
+        processor_version
+      ) values (
+        now(),
+        repeat('a', 64),
+        'success',
+        'legacy-consumer',
+        '1.0.0'
+      )
+      returning id
+    )
+    insert into public.discogs_import_run_dump (
+      import_run_id,
+      entity_type,
+      dump_id
+    )
+    select legacy_run.id, discogs_dump.entity_type, discogs_dump.id
+    from legacy_run
+    cross join public.discogs_dump;
+  "
+}
+
+seed_valid_release_relationships() {
+  local container_name=$1
+  local database_name=$2
+
+  execute_sql "$container_name" "$database_name" "
+    insert into public.master (id, created_at, last_modified_at)
+    values (1, now(), now()), (2, now(), now());
+    insert into public.release_item (
+      id, created_at, last_modified_at, master_id
+    ) values
+      (101, now(), now(), 1),
+      (102, now(), now(), 2);
+    update public.master
+    set main_release_id = case id when 1 then 101 when 2 then 102 end
+    where id in (1, 2);
+  "
+}
+
+validate_successful_migration() {
+  local container_name=$1
+  local database_name=$2
+
+  assert_scalar "$container_name" "$database_name" "
+    select count(*)
+    from public.discogs_import_run_dump
+    where import_contract_revision = 1
+  " "4"
+  assert_scalar "$container_name" "$database_name" "
+    select count(*)
+    from information_schema.columns
+    where table_schema = 'public'
+      and table_name = 'discogs_import_run_dump'
+      and column_name = 'import_contract_revision'
+      and is_nullable = 'NO'
+      and column_default is null
+  " "1"
+  assert_scalar "$container_name" "$database_name" "
+    select count(*)
+    from pg_constraint
+    where conrelid in (
+      'public.discogs_import_run_dump'::regclass,
+      'public.release_item'::regclass,
+      'public.master'::regclass
+    )
+      and conname in (
+        'ck_discogs_import_run_dump_import_contract_revision_positive',
+        'uq_release_item_master_id_id',
+        'uq_master_main_release_id',
+        'fk_master_id_main_release_id_release_item_master_id_id'
+      )
+      and convalidated
+  " "4"
+  assert_scalar "$container_name" "$database_name" "
+    select count(*)
+    from pg_constraint
+    where conrelid = 'public.master'::regclass
+      and conname = 'fk_master_main_release_id_release_item'
+  " "0"
+  assert_scalar "$container_name" "$database_name" "
+    select count(*)
+    from pg_indexes
+    where schemaname = 'public'
+      and indexname = 'ix_release_item_master_id_id'
+  " "0"
+  assert_scalar "$container_name" "$database_name" "
+    select count(*)
+    from pg_constraint constraint_definition
+    join pg_index index_definition
+      on index_definition.indexrelid = constraint_definition.conindid
+    where constraint_definition.conrelid = 'public.release_item'::regclass
+      and constraint_definition.conname = 'uq_release_item_master_id_id'
+      and index_definition.indisunique
+      and index_definition.indisvalid
+      and pg_get_indexdef(index_definition.indexrelid)
+        like '% USING btree (master_id, id)'
+  " "1"
+  assert_scalar "$container_name" "$database_name" "
+    select count(*)
+    from pg_proc function_definition
+    join pg_namespace function_schema
+      on function_schema.oid = function_definition.pronamespace
+    where function_schema.nspname = 'public'
+      and function_definition.proname =
+        'clear_stale_main_release_before_release_master_change'
+  " "1"
+  assert_scalar "$container_name" "$database_name" "
+    select count(*)
+    from pg_trigger
+    where tgrelid = 'public.release_item'::regclass
+      and tgname = 'trg_release_item_clear_stale_main_release'
+      and not tgisinternal
+      and tgenabled = 'O'
+  " "1"
+
+  expect_sql_failure "$container_name" "$database_name" "
+    with new_run as (
+      insert into public.discogs_import_run (
+        manifest_sha256, status, processor, processor_version
+      ) values (repeat('b', 64), 'running', 'new-consumer', '2.0.0')
+      returning id
+    )
+    insert into public.discogs_import_run_dump (
+      import_run_id, entity_type, dump_id
+    )
+    select new_run.id, discogs_dump.entity_type, discogs_dump.id
+    from new_run
+    join public.discogs_dump on discogs_dump.entity_type = 'artist';
+  "
+  expect_sql_failure "$container_name" "$database_name" "
+    with new_run as (
+      insert into public.discogs_import_run (
+        manifest_sha256, status, processor, processor_version
+      ) values (repeat('c', 64), 'running', 'new-consumer', '2.0.0')
+      returning id
+    )
+    insert into public.discogs_import_run_dump (
+      import_run_id, entity_type, dump_id, import_contract_revision
+    )
+    select new_run.id, discogs_dump.entity_type, discogs_dump.id, 0
+    from new_run
+    join public.discogs_dump on discogs_dump.entity_type = 'artist';
+  "
+  expect_sql_failure "$container_name" "$database_name" "
+    with new_run as (
+      insert into public.discogs_import_run (
+        manifest_sha256, status, processor, processor_version
+      ) values (repeat('d', 64), 'running', 'new-consumer', '2.0.0')
+      returning id
+    )
+    insert into public.discogs_import_run_dump (
+      import_run_id, entity_type, dump_id, import_contract_revision
+    )
+    select new_run.id, discogs_dump.entity_type, discogs_dump.id, -1
+    from new_run
+    join public.discogs_dump on discogs_dump.entity_type = 'label';
+  "
+  execute_sql "$container_name" "$database_name" "
+    with new_run as (
+      insert into public.discogs_import_run (
+        manifest_sha256, status, processor, processor_version
+      ) values (repeat('e', 64), 'running', 'new-consumer', '2.0.0')
+      returning id
+    )
+    insert into public.discogs_import_run_dump (
+      import_run_id,
+      entity_type,
+      dump_id,
+      import_contract_revision
+    )
+    select
+      new_run.id,
+      discogs_dump.entity_type,
+      discogs_dump.id,
+      case discogs_dump.entity_type
+        when 'release' then 2
+        else 1
+      end
+    from new_run
+    cross join public.discogs_dump;
+  "
+  assert_scalar "$container_name" "$database_name" "
+    select string_agg(
+      run_dump.entity_type || ':' || run_dump.import_contract_revision,
+      ',' order by run_dump.entity_type
+    )
+    from public.discogs_import_run_dump run_dump
+    join public.discogs_import_run import_run
+      on import_run.id = run_dump.import_run_id
+    where import_run.manifest_sha256 = repeat('e', 64)
+  " "artist:1,label:1,master:1,release:2"
+
+  execute_sql "$container_name" "$database_name" \
+    "update public.master set main_release_id = null where id = 2;"
+  expect_sql_failure "$container_name" "$database_name" \
+    "update public.master set main_release_id = 102 where id = 1;"
+
+  execute_sql "$container_name" "$database_name" \
+    "update public.master set main_release_id = 102 where id = 2;"
+  execute_sql "$container_name" "$database_name" \
+    "update public.release_item set master_id = 2 where id = 101;"
+  assert_scalar "$container_name" "$database_name" "
+    select count(*)
+    from public.master
+    where id = 1
+      and main_release_id is null
+  " "1"
+  assert_scalar "$container_name" "$database_name" "
+    select master_id
+    from public.release_item
+    where id = 101
+  " "2"
+
+  execute_sql "$container_name" "$database_name" \
+    "update public.master set main_release_id = 101 where id = 2;"
+  execute_sql "$container_name" "$database_name" \
+    "update public.release_item set title = 'unrelated change' where id = 101;"
+  assert_scalar "$container_name" "$database_name" \
+    "select main_release_id from public.master where id = 2" "101"
+  execute_sql "$container_name" "$database_name" "
+    update public.release_item
+    set master_id = master_id,
+        title = 'unchanged master'
+    where id = 101;
+  "
+  assert_scalar "$container_name" "$database_name" \
+    "select main_release_id from public.master where id = 2" "101"
+}
+
+validate_failed_migration_rollback() {
+  local container_name=$1
+  local database_name=$2
+
+  assert_scalar "$container_name" "$database_name" "
+    select count(*)
+    from information_schema.columns
+    where table_schema = 'public'
+      and table_name = 'discogs_import_run_dump'
+      and column_name = 'import_contract_revision'
+  " "0"
+  assert_scalar "$container_name" "$database_name" "
+    select count(*)
+    from pg_constraint
+    where conrelid = 'public.master'::regclass
+      and conname = 'fk_master_main_release_id_release_item'
+      and convalidated
+  " "1"
+  assert_scalar "$container_name" "$database_name" "
+    select count(*)
+    from pg_constraint
+    where conname in (
+      'uq_release_item_master_id_id',
+      'uq_master_main_release_id',
+      'fk_master_id_main_release_id_release_item_master_id_id'
+    )
+      and conrelid in (
+        'public.release_item'::regclass,
+        'public.master'::regclass
+      )
+  " "0"
+  assert_scalar "$container_name" "$database_name" "
+    select count(*)
+    from pg_indexes
+    where schemaname = 'public'
+      and indexname = 'ix_release_item_master_id_id'
+  " "1"
+  assert_scalar "$container_name" "$database_name" "
+    select count(*)
+    from pg_proc function_definition
+    join pg_namespace function_schema
+      on function_schema.oid = function_definition.pronamespace
+    where function_schema.nspname = 'public'
+      and function_definition.proname =
+        'clear_stale_main_release_before_release_master_change'
+  " "0"
+  assert_scalar "$container_name" "$database_name" "
+    select count(*)
+    from pg_trigger
+    where tgrelid = 'public.release_item'::regclass
+      and tgname = 'trg_release_item_clear_stale_main_release'
+      and not tgisinternal
+  " "0"
+}
+
+run_postgres_contract_test() {
+  local postgres_image=$1
+  local postgres_major
+  local container_name
+  local volume_mounts
+  local assert_tmpfs
+  local database_name
+  local tmpfs_path
+  local pgdata_path="/var/lib/postgresql/data"
+
+  postgres_major="${postgres_image#postgres:}"
+  postgres_major="${postgres_major%%.*}"
+  if (( postgres_major >= 18 )); then
+    tmpfs_path="/var/lib/postgresql"
+  else
+    tmpfs_path="$pgdata_path"
+  fi
+  container_name="open-discogs-model-release-contract-pg${postgres_major}-$$"
+  container_names+=("$container_name")
+
+  docker run \
+    --detach \
+    --name "$container_name" \
+    --label "io.dsub.test-owner=$test_owner" \
+    --label "io.dsub.test-suite=$test_suite" \
+    --label "io.dsub.test-run=$test_run" \
+    --tmpfs "$tmpfs_path:rw,noexec,nosuid,size=512m" \
+    --env "PGDATA=$pgdata_path" \
+    --env POSTGRES_PASSWORD=contracttest \
+    "$postgres_image" >/dev/null
+
+  volume_mounts="$(docker container inspect \
+    --format '{{range .Mounts}}{{if eq .Type "volume"}}{{println .Name}}{{end}}{{end}}' \
+    "$container_name")"
+  if [[ -n "$volume_mounts" ]]; then
+    while IFS= read -r volume_name; do
+      if [[ -n "$volume_name" ]]; then
+        created_volume_names+=("$volume_name")
+      fi
+    done <<< "$volume_mounts"
+    printf 'Test container created a Docker volume: %s\n' "$volume_mounts" >&2
+    return 1
+  fi
+  assert_tmpfs="$(docker container inspect \
+    --format "{{index .HostConfig.Tmpfs \"$tmpfs_path\"}}" "$container_name")"
+  if [[ "$assert_tmpfs" != *"size=512m"* \
+    && "$assert_tmpfs" != *"size=536870912"* ]]; then
+    printf 'PostgreSQL tmpfs size is not 512 MiB: %s\n' "$assert_tmpfs" >&2
+    return 1
+  fi
+  if [[ "$assert_tmpfs" != *"noexec"* \
+      || "$assert_tmpfs" != *"nosuid"* ]]; then
+    printf 'PostgreSQL data directory is not the required tmpfs: %s\n' \
+      "$assert_tmpfs" >&2
+    return 1
+  fi
+
+  wait_for_postgres "$container_name"
+
+  for database_name in contract_good contract_bad_mismatch contract_bad_duplicate; do
+    execute_sql "$container_name" postgres "create database $database_name;"
+    apply_migrations_through_v008 "$container_name" "$database_name"
+    seed_import_run "$container_name" "$database_name"
+  done
+
+  seed_valid_release_relationships "$container_name" contract_good
+  apply_v009 "$container_name" contract_good
+  validate_successful_migration "$container_name" contract_good
+
+  execute_sql "$container_name" contract_bad_mismatch "
+    insert into public.master (id, created_at, last_modified_at)
+    values (1, now(), now()), (2, now(), now());
+    insert into public.release_item (
+      id, created_at, last_modified_at, master_id
+    ) values (101, now(), now(), 2);
+    update public.master set main_release_id = 101 where id = 1;
+  "
+  if apply_v009 "$container_name" contract_bad_mismatch 2>/dev/null; then
+    printf 'V009 accepted an existing cross-master main release\n' >&2
+    return 1
+  fi
+  validate_failed_migration_rollback "$container_name" contract_bad_mismatch
+  assert_scalar "$container_name" contract_bad_mismatch "
+    select count(*)
+    from public.master master_item
+    join public.release_item release_item
+      on release_item.id = master_item.main_release_id
+    where master_item.id = 1
+      and release_item.id = 101
+      and release_item.master_id = 2
+  " "1"
+
+  execute_sql "$container_name" contract_bad_duplicate "
+    insert into public.master (id, created_at, last_modified_at)
+    values (1, now(), now()), (2, now(), now());
+    insert into public.release_item (
+      id, created_at, last_modified_at, master_id
+    ) values (101, now(), now(), 1);
+    update public.master set main_release_id = 101 where id in (1, 2);
+  "
+  if apply_v009 "$container_name" contract_bad_duplicate 2>/dev/null; then
+    printf 'V009 accepted duplicate existing main release ownership\n' >&2
+    return 1
+  fi
+  validate_failed_migration_rollback "$container_name" contract_bad_duplicate
+  assert_scalar "$container_name" contract_bad_duplicate "
+    select count(*)
+    from public.master
+    where main_release_id = 101
+  " "2"
+
+  printf 'PostgreSQL %s release convergence contract passed\n' "$postgres_major"
+}
+
+for postgres_image in "${postgres_images[@]}"; do
+  run_postgres_contract_test "$postgres_image"
+done
+
+printf 'Release convergence contract assertions passed\n'

--- a/src/main/java/io/dsub/opendiscogs/model/manifest/ImportExecution.java
+++ b/src/main/java/io/dsub/opendiscogs/model/manifest/ImportExecution.java
@@ -19,6 +19,8 @@ public final class ImportExecution {
 
   private static final Map<String, Integer> ENTITY_LOCK_KEYS =
       Map.of("artist", 1, "label", 2, "master", 3, "release", 4);
+  private static final Map<String, Integer> ENTITY_IMPORT_CONTRACT_REVISIONS =
+      Map.of("artist", 1, "label", 1, "master", 1, "release", 2);
   private static final Map<String, List<String>> ENTITY_LOCK_DEPENDENCIES =
       Map.of(
           "artist", List.of("artist"),
@@ -33,14 +35,25 @@ public final class ImportExecution {
    * Returns the stable second PostgreSQL advisory lock key for an entity type.
    */
   public static int entityLockKey(String entityType) {
-    if (entityType == null) {
-      throw new IllegalArgumentException("entity type must not be null");
-    }
-    Integer key = ENTITY_LOCK_KEYS.get(entityType.toLowerCase(Locale.ROOT));
+    Integer key = ENTITY_LOCK_KEYS.get(normalizeEntityType(entityType));
     if (key == null) {
       throw new IllegalArgumentException("unknown entity type " + entityType);
     }
     return key;
+  }
+
+  /**
+   * Returns the current stored-data semantics revision for an entity. Successful checkpoints are
+   * compatible across processors only at this revision; interrupted runs still require an exact
+   * processor name and version match.
+   */
+  public static int importContractRevision(String entityType) {
+    String normalized = normalizeEntityType(entityType);
+    Integer revision = ENTITY_IMPORT_CONTRACT_REVISIONS.get(normalized);
+    if (revision == null) {
+      throw new IllegalArgumentException("unknown entity type: " + entityType);
+    }
+    return revision;
   }
 
   /**
@@ -79,5 +92,12 @@ public final class ImportExecution {
       throw new IllegalArgumentException("candidate and checkpoint dates must not be null");
     }
     return candidate.isBefore(checkpoint);
+  }
+
+  private static String normalizeEntityType(String entityType) {
+    if (entityType == null) {
+      throw new IllegalArgumentException("entity type must not be null");
+    }
+    return entityType.toLowerCase(Locale.ROOT);
   }
 }

--- a/src/test/java/io/dsub/opendiscogs/model/manifest/ImportExecutionTest.java
+++ b/src/test/java/io/dsub/opendiscogs/model/manifest/ImportExecutionTest.java
@@ -12,6 +12,22 @@ import org.junit.jupiter.api.Test;
 class ImportExecutionTest {
 
   @Test
+  void exposesPositivePerEntityImportContractRevisions() {
+    assertEquals(1, ImportExecution.importContractRevision("artist"));
+    assertEquals(1, ImportExecution.importContractRevision("label"));
+    assertEquals(1, ImportExecution.importContractRevision("master"));
+    assertEquals(2, ImportExecution.importContractRevision("release"));
+    assertEquals(2, ImportExecution.importContractRevision("RELEASE"));
+    assertTrue(ImportExecution.importContractRevision("release") > 0);
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> ImportExecution.importContractRevision("unknown"));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> ImportExecution.importContractRevision(null));
+  }
+
+  @Test
   void exposesStableEntityLockOrderAndKeys() {
     assertEquals(
         List.of("artist", "master", "release"),


### PR DESCRIPTION
## What changed

- add V009 entity-specific import contract revisions and enforce master/main-release convergence
- publish a strict legacy Liquibase adoption contract and namespaced canonical migration resources
- verify PostgreSQL 15/18 convergence, generated models, and packaged migration bytes in CI and release workflows

## Release impact

This is a feature release because it adds a new canonical schema and import compatibility contract. Existing import-run dump rows are preserved at revision 1; current revisions are artist=1, label=1, master=1, release=2. Existing inconsistent master/main-release data fails migration without silent repair.

The new composite/unique indexes were validated on fixtures only. Production-size build time, temporary disk, and lock duration were not measured locally, so deployment requires a measured maintenance window before the 200M+ row import.

## Verification

- scripts/verify-generated-models.sh
- scripts/test-release-convergence-contract.sh (PostgreSQL 15 and 18; Docker residue 0)
- go test -race ./...
- go vet ./...
- ./gradlew clean build --no-daemon --warning-mode=fail
- actionlint
- shellcheck scripts/*.sh
- packaged migration and contract inventory byte comparison