### PR TITLE
fix: wait for final PostgreSQL test server

### DIFF
--- a/scripts/test-release-convergence-contract.sh
+++ b/scripts/test-release-convergence-contract.sh
@@ -91,10 +91,13 @@ trap 'exit 143' TERM
 wait_for_postgres() {
   local container_name=$1
 
-  for _ in {1..30}; do
-    if docker exec "$container_name" \
-      psql --username postgres --dbname postgres \
-      --no-psqlrc --tuples-only --command 'select 1' >/dev/null 2>&1; then
+  # The temporary init server accepts SQL before the entrypoint starts the final PID 1 server.
+  for _ in {1..60}; do
+    if docker exec "$container_name" sh -ceu '
+      test "$(cat /proc/1/comm)" = postgres
+      exec psql --username postgres --dbname postgres \
+        --no-psqlrc --tuples-only --command "select 1"
+    ' >/dev/null 2>&1; then
       return 0
     fi
     sleep 1


### PR DESCRIPTION
## Summary

- wait until the official PostgreSQL image has replaced its entrypoint with the final PID 1 server
- avoid accepting the temporary initialization server that shuts down before the contract test starts
- keep the readiness check bounded to 60 seconds

## Evidence

Release PR #50 failed after PostgreSQL 18 briefly accepted the readiness query and then removed its socket during the init-to-final-server handoff.

## Verification

- `shellcheck scripts/test-release-convergence-contract.sh`
- `scripts/test-release-convergence-contract.sh`
- PostgreSQL 15 and 18 passed; Docker residue verification passed