### PR TITLE
chore: migrate Cineko secrets

### DIFF
--- a/.github/workflows/migrate-cineko-probe-secrets.yml
+++ b/.github/workflows/migrate-cineko-probe-secrets.yml
@@ -1,0 +1,28 @@
+name: Migrate Cineko Probe Secrets
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  migrate:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Copy existing deployment secrets to Cineko Probe
+        env:
+          GH_TOKEN: ${{ secrets.CINEKO_ORG_MIGRATION_TOKEN }}
+          KOMODO_URL: ${{ secrets.KOMODO_URL }}
+          KOMODO_API_KEY: ${{ secrets.KOMODO_API_KEY }}
+          KOMODO_API_KEY_SECRET: ${{ secrets.KOMODO_API_KEY_SECRET }}
+        run: |
+          set -euo pipefail
+          for name in KOMODO_URL KOMODO_API_KEY KOMODO_API_KEY_SECRET; do
+            value="${!name:-}"
+            if [ -z "${value}" ]; then
+              echo "Missing source secret: ${name}" >&2
+              exit 1
+            fi
+            printf '%s' "${value}" | gh secret set "${name}" --repo cineko-org/probe
+          done


### PR DESCRIPTION
Temporary workflow that copies the existing dsub Komodo secrets to the private Cineko Probe repository without exposing or rotating values. It will be removed immediately after the one-time run.