### PR TITLE
perf: optimize combined release filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,8 +130,9 @@ separate, audited downgrade option is explicitly requested.
 The schema also owns the bounded read-path indexes used by the Go API. Trigram
 indexes cover artist and label names plus master and release titles; no index is
 created for large profile, contact, or notes fields. Reverse relationship keys
-and release date, country, master, and master-membership filters have dedicated
-indexes. PostgreSQL installations must make the bundled `pg_trgm` extension
+and release date, country, master, master-membership, and combined
+country/master/date filters have dedicated indexes. PostgreSQL installations
+must make the bundled `pg_trgm` extension
 available to the migration owner. Canonical batch finalization analyzes newly
 bootstrapped tables before serving traffic so the planner sees the imported data
 distribution.

--- a/docs/performance/2026-08-13-release-combined-filter-index.md
+++ b/docs/performance/2026-08-13-release-combined-filter-index.md
@@ -1,0 +1,48 @@
+# Combined release filter index benchmark (2026-08-13)
+
+## Result
+
+`V022__release_combined_filter_index.sql` bounds the API query that combines
+country, master status, release date, and cursor filters.
+
+| Query | Before p50 / p95 / p99 | After p50 / p95 / p99 | p99 change |
+| --- | ---: | ---: | ---: |
+| Combined release filter | 5.792 / 6.610 / 6.856 ms | 0.185 / 0.208 / 0.225 ms | 96.7% lower |
+
+Before V022, PostgreSQL used `ix_release_item_release_date_id`, visited 4,386
+heap blocks, filtered country and master status, and performed a top-N sort.
+After V022 it used an ordered scan on
+`ix_release_item_country_master_id_date`, returned 31 rows from 53 shared-buffer
+hits, and did not sort or use temporary blocks.
+
+The new index was 31,522,816 bytes for 1,000,000 synthetic releases. The test
+database changed from 486,405,823 to 517,953,215 bytes, an increase of
+31,547,392 bytes or 6.5% after the earlier V007 API indexes were already
+present.
+
+## Conditions
+
+- Apple M2 Pro host, arm64, 12 Docker CPUs, 8 GiB Docker memory
+- PostgreSQL 18.4 Alpine on a 4 GiB tmpfs; no persistent Docker volume
+- 1,000,000 releases, 1,000,000 release-artist relations, 250,000 artists,
+  250,000 masters, and 100,000 labels
+- one client, JIT disabled, five warm-up executions, then 30 measured executions
+- identical data and container before and after V022; `ANALYZE` ran before each
+  phase
+
+Run from the model repository root:
+
+```sh
+scripts/benchmark-api-query-indexes.sh
+```
+
+The script prints percentile summaries, JSON query plans, database sizes, and
+the V022 index size. It owns an exact labeled tmpfs container and removes it on
+success, failure, or interruption.
+
+## Limits
+
+This is a warm-cache synthetic query benchmark. The measured index size and
+latency cannot be extrapolated directly to the monthly 200-million-row data
+distribution. Full-data storage sizing, index-build duration, import impact,
+and cold I/O remain pre-production checks.

--- a/schema/embed_test.go
+++ b/schema/embed_test.go
@@ -40,6 +40,7 @@ func TestMigrations(t *testing.T) {
 		"V019__remove_relation_surrogate_ids.sql",
 		"V020__bootstrap_foreign_key_finalization.sql",
 		"V021__non_release_relation_identity.sql",
+		"V022__release_combined_filter_index.sql",
 	}
 	if len(entries) != len(want) {
 		t.Fatalf("migration count = %d, want %d", len(entries), len(want))

--- a/schema/migrations/V022__release_combined_filter_index.sql
+++ b/schema/migrations/V022__release_combined_filter_index.sql
@@ -1,0 +1,6 @@
+create index if not exists ix_release_item_country_master_id_date
+    on public.release_item (lower(country), is_master, id, release_date)
+    where has_valid_year is true;
+
+comment on index public.ix_release_item_country_master_id_date is
+    'Bounds country, master-status, and release-date API filtering while preserving cursor ID order.';

--- a/scripts/benchmark-api-query-indexes.sh
+++ b/scripts/benchmark-api-query-indexes.sh
@@ -177,6 +177,7 @@ keyset_query="select id from release_item where id > $((release_rows - 100)) ord
 exact_count_query="select count(*) from release_item"
 title_query="select id from release_item where title ilike '%rare needle%' and id > 0 order by id limit 31"
 relationship_query="select release_item_id from release_item_artist where artist_id = $((artist_rows - 1)) and release_item_id > 0 order by release_item_id limit 31"
+combined_release_query="select id from release_item where lower(country) = 'gb' and has_valid_year is true and release_date >= date '2000-03-01' and release_date < date '2000-04-01' and is_master is true and id > 0 order by id limit 31"
 
 printf 'phase\tquery\tp50_ms\tp95_ms\tp99_ms\n'
 benchmark_query before deep_offset "$deep_offset_query"
@@ -198,6 +199,18 @@ psql_command 'analyze;'
 benchmark_query after keyset "$keyset_query"
 benchmark_query after title_contains "$title_query"
 benchmark_query after artist_releases "$relationship_query"
+benchmark_query before_composite release_combined_filter "$combined_release_query"
 printf 'plan_after\ttitle_contains\t%s\n' "$(query_plan "$title_query")"
 printf 'plan_after\tartist_releases\t%s\n' "$(query_plan "$relationship_query")"
 printf 'size_after_bytes\t%s\n' "$(psql_command "select pg_database_size(current_database())")"
+
+docker exec --interactive "$container_name" \
+  psql --username modelbench --dbname modelbench \
+    --no-psqlrc --quiet --set ON_ERROR_STOP=1 \
+    < "$repository_root/schema/migrations/V022__release_combined_filter_index.sql"
+psql_command 'analyze release_item;'
+
+benchmark_query after_composite release_combined_filter "$combined_release_query"
+printf 'plan_after_composite\trelease_combined_filter\t%s\n' "$(query_plan "$combined_release_query")"
+printf 'combined_index_bytes\t%s\n' "$(psql_command "select pg_relation_size('ix_release_item_country_master_id_date')")"
+printf 'size_after_composite_bytes\t%s\n' "$(psql_command "select pg_database_size(current_database())")"


### PR DESCRIPTION
## What changed

- add canonical V022 index for country, master-status, release-date, and cursor filtering
- extend the model-owned query benchmark and migration inventory test
- record reproducible before/after plans, latency, and index-size evidence

## Why

The combined release filter used the release-date index, visited thousands of heap blocks, filtered the remaining predicates, and sorted before returning one page. The new index preserves cursor ID order while applying the complete filter at the index scan.

## Measured impact

On the documented 1,000,000-release fixture, p99 changed from 6.856 ms to 0.225 ms (-96.7%). The plan changed from 4,386 heap blocks plus top-N sort to an ordered 53-buffer index scan. The index added 31,522,816 bytes (+6.5% to the post-V007 test database).

## Validation

- `go test ./...`
- `scripts/verify-generated-models.sh`
- `./gradlew clean build --no-daemon --warning-mode=fail`
- `scripts/test-release-convergence-contract.sh` on PostgreSQL 15 and 18
- `scripts/benchmark-api-query-indexes.sh`

The benchmark remains manual and does not run on pull requests.