### PR TITLE
feat: add exact release lookup indexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,11 +131,20 @@ The schema also owns the bounded read-path indexes used by the Go API. Trigram
 indexes cover artist and label names plus master and release titles; no index is
 created for large profile, contact, or notes fields. Reverse relationship keys
 and release date, country, master, master-membership, and combined
-country/master/date filters have dedicated indexes. PostgreSQL installations
+country/master/date filters have dedicated indexes. Exact Label/catalog-number
+and identifier type/value Release lookups use dedicated cursor-compatible
+indexes; identifier queries recheck the original value after their bounded hash
+lookup. PostgreSQL installations
 must make the bundled `pg_trgm` extension
 available to the migration owner. Canonical batch finalization analyzes newly
 bootstrapped tables before serving traffic so the planner sees the imported data
 distribution.
+V023 builds the two exact-lookup indexes over existing relation rows. Apply it
+only while Go and Java importers are stopped and reserve maintenance I/O, WAL,
+and temporary disk headroom appropriate to the populated tables. API reads may
+continue, but the new exact lookup routes must not be deployed until V023 has
+completed. The migration changes no relation identity or import contract
+revision.
 The reproducible synthetic before/after results and their full-dump limitations
 are recorded in
 [`docs/performance/2026-08-11-api-query-indexes.md`](docs/performance/2026-08-11-api-query-indexes.md).

--- a/schema/embed_test.go
+++ b/schema/embed_test.go
@@ -41,6 +41,7 @@ func TestMigrations(t *testing.T) {
 		"V020__bootstrap_foreign_key_finalization.sql",
 		"V021__non_release_relation_identity.sql",
 		"V022__release_combined_filter_index.sql",
+		"V023__release_exact_lookup_indexes.sql",
 	}
 	if len(entries) != len(want) {
 		t.Fatalf("migration count = %d, want %d", len(entries), len(want))

--- a/schema/migrations/V023__release_exact_lookup_indexes.sql
+++ b/schema/migrations/V023__release_exact_lookup_indexes.sql
@@ -1,0 +1,17 @@
+create index if not exists ix_label_release_item_label_catalog_release
+    on public.label_release_item (label_id, category_notation, release_item_id)
+    where category_notation is not null;
+
+create index if not exists ix_release_item_identifier_type_value_release
+    on public.release_item_identifier (
+        lower(type),
+        decode(md5(value), 'hex'),
+        release_item_id
+    )
+    where type is not null and value is not null;
+
+comment on index public.ix_label_release_item_label_catalog_release is
+    'Supports exact Label and catalog-number Release lookup with ID cursor pagination.';
+
+comment on index public.ix_release_item_identifier_type_value_release is
+    'Supports exact identifier type and value Release lookup with ID cursor pagination; queries recheck the original value after the bounded MD5 lookup.';

--- a/scripts/test-migrations.sh
+++ b/scripts/test-migrations.sh
@@ -133,7 +133,7 @@ if [[ "$row_count" != 3 ]]; then
   exit 1
 fi
 
-for version in $(seq -f '%03g' 9 21); do
+for version in $(seq -f '%03g' 9 23); do
   migration="$(find "$repository_root/schema/migrations" \
     -maxdepth 1 -type f -name "V${version}__*.sql" -print -quit)"
   if [[ -z "$migration" ]]; then
@@ -144,6 +144,28 @@ for version in $(seq -f '%03g' 9 21); do
     psql --username migrationtest --dbname migrationtest \
     --set ON_ERROR_STOP=1 < "$migration" >/dev/null
 done
+
+exact_lookup_indexes="$(docker exec "$container_name" \
+  psql --username migrationtest --dbname migrationtest \
+  --no-align --tuples-only \
+  --command "
+    select indexname
+    from pg_indexes
+    where schemaname = 'public'
+      and indexname in (
+        'ix_label_release_item_label_catalog_release',
+        'ix_release_item_identifier_type_value_release'
+      )
+    order by indexname
+  ")"
+expected_exact_lookup_indexes="$(printf '%s\n' \
+  'ix_label_release_item_label_catalog_release' \
+  'ix_release_item_identifier_type_value_release')"
+if [[ "$exact_lookup_indexes" != "$expected_exact_lookup_indexes" ]]; then
+  printf 'Unexpected exact lookup index inventory:\n%s\n' \
+    "$exact_lookup_indexes" >&2
+  exit 1
+fi
 
 non_release_identity_inventory="$(docker exec "$container_name" \
   psql --username migrationtest --dbname migrationtest \


### PR DESCRIPTION
Adds canonical PostgreSQL indexes required by the new exact release lookup API.

- indexes label plus catalog number lookups
- indexes identifier type plus value lookups with an exact-value recheck contract
- documents the no-import migration window and resource requirements
- extends migration inventory and PostgreSQL integration coverage through V023

Validation:
- go test ./...
- scripts/test-migrations.sh
- scripts/verify-generated-models.sh
- ./gradlew clean build --no-daemon --warning-mode=fail

Operational note: stop Go and Java importers while V023 is applied. Read-only API traffic may continue.